### PR TITLE
ci(intake): capture architect transcript and dump claude stdout on failure

### DIFF
--- a/.github/workflows/agent-intake.yml
+++ b/.github/workflows/agent-intake.yml
@@ -150,7 +150,8 @@ jobs:
           python tooling/orchestrator_run.py \
             --phase architect --mode release \
             --scope "$SCOPE" \
-            --usage-jsonl artifacts/usage.jsonl
+            --usage-jsonl artifacts/usage.jsonl \
+            --transcript artifacts/architect.transcript.json
 
       - name: Validate specs (post-architect)
         run: python tooling/validate_specs.py --verbose
@@ -263,6 +264,7 @@ jobs:
             artifacts/agent_changes.diff
             artifacts/issue_scope.md
             artifacts/extractor.transcript.json
+            artifacts/architect.transcript.json
             work/
           if-no-files-found: warn
           retention-days: 14

--- a/tooling/orchestrator_run.py
+++ b/tooling/orchestrator_run.py
@@ -244,7 +244,11 @@ def run_real(
         transcript.write_text(proc.stdout, encoding="utf-8")
 
     if proc.returncode != 0:
+        # Without this dump the JSON error body is invisible whenever
+        # --transcript wasn't passed, leaving the operator blind.
         sys.stderr.write(proc.stderr)
+        sys.stderr.write("\n--- claude stdout (error body) ---\n")
+        sys.stderr.write(proc.stdout)
         raise SystemExit(
             f"claude CLI exited {proc.returncode} for phase '{phase}'."
         )


### PR DESCRIPTION
## Summary

- Issue #6 / run [#25252566454](https://github.com/RuslanMingaliev/worldsmith/actions/runs/25252566454): Architect phase exited 1 with no captured stdout or stderr in the workflow log, so the actual failure reason is lost.
- Architect step wasn't passing \`--transcript\` (only Extractor was), and the orchestrator discarded claude's stdout on non-zero exit.
- Adds Architect transcript path + uploads it as an artifact.
- Makes \`orchestrator_run.py\` dump \`proc.stdout\` to stderr on non-zero exit so the JSON error body is visible even without an explicit \`--transcript\`.

## Test plan

- [ ] validate passes; regenerate-and-build skipped (no source-of-truth path).
- [ ] Next agent-intake run that fails leaves \`artifacts/architect.transcript.json\` and writes the error body into the workflow log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)