### PR TITLE
agent: refresh from issue #6

### DIFF
--- a/ir/module_contracts.yaml
+++ b/ir/module_contracts.yaml
@@ -148,6 +148,74 @@ modules:
       geometry, not the loop.
 
   # ---------------------------------------------------------------------------
+  - name: level_generator
+    file: src/level_generator.rs
+    depends_on: [level_data]
+    public_types:
+      - name: DemoLevelKind
+        definition: |
+          #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
+          #[serde(rename_all = "snake_case")]
+          pub enum DemoLevelKind {
+              LocalChaseObstacle,
+          }
+        notes: |
+          Public because autopilot::Scenario.level holds
+          Option<DemoLevelKind> (specs/15 § Scenario YAML Extension), so
+          serde_yaml can deserialize the YAML name directly into the
+          enum. `rename_all = "snake_case"` maps `LocalChaseObstacle`
+          -> `local_chase_obstacle` for YAML readability. Adding a new
+          demo level: add one variant here and one match arm in build()
+          below; nothing else changes.
+    public_constants: []
+    public_methods:
+      - signature: "pub fn build(kind: DemoLevelKind) -> Level"
+        notes: |
+          Pure function: same `kind` always returns a byte-equal Level.
+          No I/O, no randomness, no global state. Per specs/15 §
+          Determinism this purity is the spec's full contribution to the
+          determinism contract; everything else (RNG seeds, fixed dt,
+          frame recording format) is already pinned by specs/35.
+          Implementation pattern (one match arm per variant):
+            match kind {
+                DemoLevelKind::LocalChaseObstacle => build_local_chase_obstacle(),
+            }
+          where build_local_chase_obstacle() is a private helper that
+          returns the Level layout pinned in specs/15 § LocalChaseObstacle.
+      - signature: "fn build_local_chase_obstacle() -> Level"
+        notes: |
+          Module-private. Builds the LocalChaseObstacle layout from
+          specs/15 § LocalChaseObstacle. Concretely:
+            width = GRID_WIDTH (20); height = GRID_HEIGHT (15);
+            tiles[y][x] = Wall iff (x == 0 || x == 19 || y == 0 || y == 14
+                          || (x == 10 && (4..=10).contains(&y)))
+                          else Floor;
+            player_spawn = Vec2::new(3.5, 7.5);
+            enemy_spawns = vec![Vec2::new(16.5, 7.5)];
+            exit         = Vec2::new(1.5, 1.5);
+            pickups      = vec![];   // no pickups
+          Reuses GRID_WIDTH / GRID_HEIGHT from level_data; does not
+          introduce new constants. Coder may inline the layout (one
+          double-loop over the grid is the obvious form) or use a small
+          helper -- the *Level* it produces is what matters.
+    cross_module_borrows: []
+    notes: |
+      Consumed by main.rs at startup (one call per --autopilot launch
+      whose scenario sets `level: <name>`) and by autopilot for the
+      `DemoLevelKind` type only (Scenario.level is
+      Option<DemoLevelKind>). NOT consumed by any per-frame path:
+      game_loop::update, autopilot::bot_step, enemy_logic::update,
+      weapon_system::fire all stay unaware of this module. This keeps
+      the generator out of gameplay runtime per the issue's
+      "Generator must not be part of gameplay runtime logic" constraint.
+
+      Determinism: build() is a pure function; identical inputs produce
+      byte-equal Level structs. Demo recordings inherit determinism
+      from specs/35 § Determinism (fixed dt, fixed RNG seeds, fixed
+      framebuffer format) plus this purity guarantee — no scenario-RNG
+      shenanigans needed.
+
+  # ---------------------------------------------------------------------------
   - name: player_state
     file: src/player_state.rs
     depends_on: [level_data]
@@ -752,15 +820,27 @@ modules:
           }
     public_constants: []
     public_methods:
-      - signature: "pub fn new() -> GameState"
+      - signature: "pub fn new(level: Level) -> GameState"
         notes: |
-          Constructs GameState from Level::build_default():
-            level = level_data::build_default()
+          Constructs GameState from a caller-supplied Level. Caller is
+          responsible for choosing the level (default vs. demo); this
+          constructor is level-agnostic.
             player = Player::new(level.player_spawn)
             enemies = level.enemy_spawns.iter()
                           .map(|&s| Enemy::new(s)).collect()
             fx = VisualEffects::new()
             running = true; won = false; (#[cfg(test)] frames = 0)
+            level (moved into GameState as state.level)
+          Per specs/15 § game_loop::new constructor signature, main.rs
+          picks the level via:
+            let level = match autopilot_scenario.as_ref().and_then(|s| s.level) {
+                Some(kind) => level_generator::build(kind),
+                None       => level_data::build_default(),
+            };
+            let mut game = game_loop::new(level);
+          Interactive play (no --autopilot) always passes
+          level_data::build_default(). The generator is never called from
+          inside game_loop or any other per-frame path.
       - signature: "pub fn update(state: &mut GameState, input: &InputState, dt: f32)"
         notes: |
           ONE per-frame tick. Order is pinned by frame_update_order
@@ -784,6 +864,7 @@ modules:
       - game_loop
       - input_controller
       - level_data
+      - level_generator
       - player_state
       - enemy_logic
     public_types:
@@ -794,11 +875,23 @@ modules:
           pub struct Scenario {
               pub scenario: String,
               pub description: String,
+              #[serde(default)]
+              pub level: Option<crate::level_generator::DemoLevelKind>,
               pub objectives: Vec<Objective>,
               #[serde(default)]
               pub assertions: Vec<Assertion>,
           }
         cfg_test_only: false
+        notes: |
+          `level` (specs/15) is optional. Absent => caller (main.rs)
+          uses level_data::build_default(). Present => caller calls
+          level_generator::build(kind). The serde rename_all attribute
+          on DemoLevelKind handles snake_case YAML names
+          (e.g. `local_chase_obstacle`). Unknown names yield a
+          serde_yaml deserialization error which `parse_scenario`'s
+          `.expect("valid scenario YAML")` propagates as a panic with
+          a clear message — matching the existing parse error handling
+          rule in specs/30 § Execution Rules.
       - name: Objective
         definition: |
           #[derive(Debug, serde::Deserialize)]
@@ -1053,13 +1146,22 @@ main_cli:
         Existing behavior. minifb window opened, input_controller::poll
         each frame, dt from Instant::now() deltas, RNGs seeded as today.
         No frame_recorder used.
+        Level: always level_data::build_default(); the interactive path
+        does not parse scenarios so scenario.level is irrelevant here.
+            let level = level_data::build_default();
+            let mut game = game_loop::new(level);
     autopilot_only:
       trigger: "--autopilot <path>"
       behavior: |
         1. yaml = std::fs::read_to_string(path).expect("scenario file readable")
         2. scenario = autopilot::parse_scenario(&yaml)
         3. bot = autopilot::BotState::new()
-        4. game = game_loop::new()
+        4. Pick the level from scenario.level (specs/15):
+             let level = match scenario.level {
+                 Some(kind) => level_generator::build(kind),
+                 None       => level_data::build_default(),
+             };
+             let mut game = game_loop::new(level);
         5. each frame:
              (input, progress) = autopilot::bot_step(&game, &scenario, &mut bot);
              game_loop::update(&mut game, &input, BOT_FRAME_TIME);  // fixed dt!
@@ -1084,6 +1186,8 @@ main_cli:
         interactive mode -- this mode is NOT deterministic; it captures
         whatever the human plays. (Useful for ad-hoc captures, not for
         release demos.)
+        Level: same as interactive (level_data::build_default()) — no
+        scenario is parsed in this mode.
     autopilot_and_record:
       trigger: "--autopilot <path> --record-frames <out>"
       behavior: |
@@ -1091,6 +1195,10 @@ main_cli:
         dumped via frame_recorder::write_frame. THIS is the canonical
         release-demo invocation. Two runs produce byte-identical files
         (specs/35 § Acceptance Criteria).
+        Level selection follows autopilot_only (specs/15): scenario.level
+        Some(kind) => level_generator::build(kind), None => default.
+        The PR-preview scenario tests/level/local_chase_obstacle.yaml
+        sets level: local_chase_obstacle and is the canonical input here.
 
   rng_seeding:
     notes: |

--- a/ir/module_plan.yaml
+++ b/ir/module_plan.yaml
@@ -3,6 +3,17 @@ modules:
     responsibility: static map and spawn positions
     depends_on: []
 
+  - name: level_generator
+    responsibility: |
+      Demo-only level builder (specs/15). Owns DemoLevelKind enum and a
+      pure `build(kind) -> Level` function. Returns the same Level type
+      that level_data::build_default returns; the runtime cannot tell which
+      builder produced a given Level. NOT consumed by any per-frame path
+      — only main.rs (once at startup, when --autopilot scenario.level is
+      Some) and autopilot's Scenario type (the DemoLevelKind enum is
+      referenced as Scenario.level: Option<DemoLevelKind>).
+    depends_on: [level_data]
+
   - name: player_state
     responsibility: player position, direction, health if needed
     depends_on: [level_data]
@@ -51,11 +62,15 @@ modules:
       (parse_scenario, bot_step, BotState, BotProgress, Scenario, Objective)
       are always compiled and consumed by main.rs in --autopilot mode
       (specs/35). The batch test runner (run_scenario, run_all_scenarios)
-      is #[cfg(test)]-gated.
+      is #[cfg(test)]-gated. Scenario.level: Option<DemoLevelKind> picks
+      a generated demo level when set (specs/15); main.rs decides whether
+      to call level_generator::build or level_data::build_default based on
+      that field.
     depends_on:
       - game_loop
       - input_controller
       - level_data
+      - level_generator
       - player_state
       - enemy_logic
 
@@ -81,6 +96,7 @@ modules:
       list stays complete.
     depends_on:
       - level_data
+      - level_generator
       - player_state
       - input_controller
       - visual_effects

--- a/knowledge/level_scenarios.md
+++ b/knowledge/level_scenarios.md
@@ -1,0 +1,71 @@
+# Finding: Level Scenarios (Scripted Entity Placement + Deterministic Replay)
+
+## Summary
+
+The reference game treats a level as two concerns that are kept strictly separate: a static geometry description (lines and sectors) and a list of entity-placement records ("things"). Every entity that exists at the start of a level — player spawn, monsters, pickups, decorations — is one fixed-shape record in that list, processed by a single dispatch loop at level-init. Combined with a fixed-table pseudo-random sequence that is reset to a known state at level-init, this gives the engine a surprisingly small surface for "purpose-built scenario": author a tiny geometry, append a few entity-placement records, reset the random index, and the resulting playback is byte-stable.
+
+Two behaviors make such scenarios visually informative for a chase-around-obstacle demo: (a) enemies move on an 8-direction discrete grid with a short commitment counter, so direction changes are visible per-tick rather than averaged into a smooth curve; (b) the chase routine treats blockage and "commitment expired" as the same trigger — both call the same direction-reselection routine, which prefers a direct diagonal toward the target before falling through to perpendicular and finally a full 8-direction sweep.
+
+## Observed Mechanics
+
+### Entity Placement Record
+
+- **Behavior**: A level's entity content is a flat array of fixed-size records. Each record is exactly five small integers — world x, world y, facing angle (in degrees), a numeric type tag, and a bitmask of placement options (skill-level mask, multiplayer-only flag, etc.). At level-init, the engine walks the array and dispatches each record by its type tag to a corresponding spawn routine.
+- **Rules**:
+  - Type tags are dense small integers, not strings. The dispatch is a linear scan over a table of "entity info" rows, one per known type, looking for a matching tag.
+  - Position is in world units (the same units the simulation uses for movement and collision); facing is quantized to 45° increments before being stored on the live entity.
+  - A handful of type tags are reserved for the player's spawn point — they don't create a free-standing entity, they instead bind a position and angle to the (already-existing) player-state and put the player in a "live" state.
+  - Options bits filter records out before dispatch (e.g. "this thing only exists on hard skill", "this thing only exists in multiplayer"). A scenario that wants every record to spawn unconditionally simply sets all relevant bits.
+- **Constants**:
+  - Record size: 5 short integers (10 bytes when packed, but the format is what matters, not the byte layout).
+  - Facing quantization: 45° increments (8 distinct facings).
+  - Reserved spawn-point type tags: a small contiguous range at the bottom of the type space (the first few tags map to player slots, not to free entities).
+- **Feel**: Because every entity is "just another row", the reference game has no concept of a "scenario" as a distinct object — it gets scenario-style determinism for free by writing tiny levels with hand-picked rows. There is no procedural generator, no template language, no DSL. The generator is the level author.
+
+### Obstacle-Aware Chase (Direction Reselection)
+
+- **Behavior**: An enemy in the chase state moves in one of 8 discrete directions (cardinal + diagonal). On each behavior tick, the enemy decrements a commitment counter; when the counter reaches zero — or when an attempted move is blocked by geometry or another entity — the enemy reselects its direction. After committing to a new direction, the counter is re-randomized to a small value (0–15 ticks), so direction changes stay visible but the entity does not jitter every frame.
+- **Rules** (direction-reselection algorithm, in priority order):
+  1. **Direct diagonal toward target.** Compute the world-axis preference along x and y from the displacement vector to the target (ignoring an axis if the displacement on it is below a small dead-band). If both axes have a preference, try the diagonal that combines them.
+  2. **Perpendicular alternates.** If the diagonal failed (or one axis was dead), try the two pure-axis directions individually. The order in which they are tried is biased: roughly 80% of the time the algorithm tries the larger-displacement axis first; the remaining 20% it swaps. The "swap" branch also fires unconditionally when the y-displacement magnitude exceeds the x-displacement magnitude — making the rare-direction choice slightly more interesting near vertical chases.
+  3. **Continue old direction.** If neither perpendicular worked, retry the direction the entity was already moving in. This is what produces the characteristic "skim along a wall" behavior — the enemy runs parallel to an obstacle until it ends.
+  4. **Full 8-direction sweep.** Iterate every direction (excluding the U-turn back toward where the enemy just came from). The iteration order is itself randomized — half the time it sweeps clockwise from east, half the time counter-clockwise from south-east — so two enemies stuck against the same obstacle don't always pick the same escape.
+  5. **U-turn.** Last-resort: turn around 180°. If even that fails, the enemy enters a "no direction" state and stops moving until something changes.
+  - Each candidate direction is validated by an actual movement attempt (collision-checked against geometry and other entities). The reselection routine commits as soon as one attempt succeeds; later candidates are not considered.
+  - The U-turn direction is excluded from priorities 2 and 4 explicitly. The reference does this so that enemies never oscillate between two directions on consecutive ticks — without this exclusion, an enemy that gets briefly blocked would frequently snap back the way it came.
+- **Constants**:
+  - Direction count: 8 (cardinals + diagonals), plus a sentinel "no direction" state.
+  - Displacement dead-band: 10 world units. Within ±10 of perfect alignment on an axis, that axis is treated as "no preference" rather than rounded to one direction or the other.
+  - Commitment counter range after a successful direction commit: 0–15 ticks (inclusive).
+  - Perpendicular-swap probability: ~22% (the random byte > 200 out of 256). Boosted to 100% when |dy| > |dx|.
+  - Sweep-direction coin: 50/50.
+- **Feel**: The combination of "commit for 0–15 ticks then reconsider" with "blockage forces immediate reconsideration" is what makes enemies look intent rather than twitchy. They visibly slide along walls, round corners, and only lose the player when an obstacle pushes them through the full priority chain. For a chase-around-obstacle demo, an obstacle that occupies the diagonal between enemy and player forces priority 1 to fail; the enemy then takes a perpendicular and skims the obstacle (priority 3) — exactly the behavior such a demo is meant to show.
+
+### Determinism Preconditions
+
+- **Behavior**: The engine produces byte-identical playback for a given input scenario when three preconditions hold: the random sequence is reset to a known state at level-init, the simulation steps at a fixed time-per-tick (decoupled from rendering), and player input is replayed from a recorded stream rather than read from the live device.
+- **Rules**:
+  - **Random sequence**. The engine carries a single 256-byte fixed table and two byte-wide indices into it (one for gameplay, one for cosmetic uses). Each call returns the table value at the next index and increments the index modulo 256. There is no seed-from-time, no hash-from-platform-state — the sequence is the table. At every level-init the engine zeros both indices, so any scenario starts from the same first random byte regardless of what happened before.
+  - **Fixed simulation step**. The simulation runs at a fixed tick rate (35 ticks per second in the reference; the rate itself is not the point — the determinism property is). Per-tick logic uses `1/tick_rate` as its delta, never wall-clock deltas. The renderer is allowed to sample the simulation at the host's actual frame rate, but the simulation itself never sees host timing.
+  - **Recorded input replay**. Demo playback substitutes a recorded byte stream for the live input device. The replay code path is otherwise the same as live play — same tick loop, same simulation, same random table — so the only source of non-determinism that remains is the input stream, and that is what was recorded.
+- **Constants**:
+  - Random table: 256 bytes, fixed values, hardcoded.
+  - Index width: one byte each (so the period is 256 calls before the table repeats — short by modern standards, but adequate for the gameplay uses it serves).
+  - Tick rate: 35 Hz in the reference. (The current project's spec uses 60 Hz; the determinism property is independent of the specific rate.)
+- **Feel**: The "reset at level-init" rule is what makes scenarios composable. An author can write a tiny level, know that a fresh load will deterministically produce the same monster behavior, and trust that the demo recorded today will be byte-identical to the demo recorded a year from now from the same level + the same recorded inputs.
+
+## Key Insights
+
+- **A "scenario" needs almost no new abstraction.** The reference shows that "purpose-built scripted level" is just (a) a tiny geometry description and (b) a short list of entity-placement records, processed by exactly the same code path that processes any other level. A project introducing a level-generator abstraction does not need a generator class hierarchy or a procedural pipeline — it needs a way to produce one geometry and one entity list, then hand both to whatever already loads levels.
+- **Entity placement is a flat record, not an object graph.** Five numbers per entity — position, facing, type tag, options — is enough to fully specify any spawnable entity. A scenario abstraction that sticks to this shape stays trivially serializable, trivially diff-able, and avoids accidentally encoding behavior in placement data.
+- **Demo-quality "navigates around an obstacle" is already produced by the existing chase loop**, provided two things are true: (a) the obstacle is solid to the enemy's collision check, and (b) the obstacle is positioned roughly between the enemy and the target. Priority 1 of the reselection algorithm fails (diagonal blocked); priority 2 picks the perpendicular that opens up; the commitment counter then keeps the enemy on that perpendicular long enough to be visually obvious before the next reselection rounds the corner. Authors do not need to encode pathfinding waypoints — they only need to author the obstacle.
+- **Determinism is a precondition, not a feature.** Three rules — reset random state at level-init, fixed simulation step, recorded input — are all that is needed. None of the three involves the scenario itself. A scenario abstraction that adds its own RNG seeding is solving a problem that was already solved upstream; it should instead document its dependence on the existing reset.
+- **Reserve the type-tag space for spawn points distinctly from free entities.** The reference uses the bottom of the type space for player-slot spawn points and emits them through a different code path than free entities (they bind to a player object rather than spawning one). A scenario abstraction that wants to specify both player and enemies in one list can mirror this split — keep one small reserved range for spawn points, use the rest for actual entity types — rather than introducing two separate lists.
+- **Commitment-counter granularity sets the visual "decision rate" of a chase demo.** A counter range of 0–15 ticks at 35 Hz means an enemy reconsiders direction roughly every 0.2 seconds on average. Halving or doubling the range produces visibly twitchier or visibly more committed enemies. For a short demo recording (under 10 seconds), the existing range produces 30–50 visible decisions — plenty of opportunity for a chase-around-obstacle to show priority-1 failures and priority-3 wall-skimming.
+
+## Open Questions
+
+- The reference's options-bitmask filtering (skill-level, multiplayer-only) is straightforward to ignore when authoring scenarios, but if a scenario abstraction wants to support "this entity only spawns when scenario flag X is set", a similar bitmask is the natural place to put it. Worth deciding once whether scenario abstractions get an analogous filter or whether they spawn unconditionally.
+- The reference's perpendicular-swap probability (~22%) and the dead-band (10 world units) are tuned to one specific simulation rate and one specific entity-radius scale. A spec adopting them verbatim should record where the values come from and whether the project's units justify keeping them, scaling them, or replacing them.
+- The reference's chase routine does not look ahead — it commits one direction, walks, then on the next reselection re-evaluates. For a scenario where a single obstacle is small relative to the entity's commitment-counter walk distance, this works well. For obstacles wider than `commitment_counter_max × per-tick step`, the enemy might walk past the obstacle and have to backtrack. Worth measuring whether any planned scenario exceeds that ratio before designing the obstacle layout.
+- The reference uses a separate gameplay-vs-cosmetic random index split. The current project may or may not need that split — only relevant if cosmetic randomness (visual variation, particle jitter) gets added later and we want gameplay determinism preserved when those visuals change.

--- a/specs/15_level_generator.md
+++ b/specs/15_level_generator.md
@@ -1,0 +1,188 @@
+# Level Generator (Demo Scenarios)
+
+## Intent
+
+Some autopilot scenarios — particularly the one driving the PR-preview GIF — need a purpose-built level whose layout is chosen to demonstrate a specific gameplay behavior in a few seconds. The default level (`level_data::build_default`) is fine for general regression tests but is too cluttered to read at a glance: a short GIF of the bot wandering between an interior wall and a horizontal divider does not visually answer the question "did the enemy navigate around the obstacle?".
+
+This spec defines a minimal `level_generator` module that produces a small, named, fully-deterministic `Level` for each demo scenario, and a tiny extension to the autopilot scenario YAML that lets a scenario opt into one of those levels by name.
+
+The abstraction is deliberately small. There is no procedural generation, no template language, no DSL — each demo level is a hand-authored builder function that returns a `Level`. Adding a new demo level means adding one variant to an enum and one function, then naming the variant in a scenario YAML's `level:` field.
+
+The knowledge basis is `knowledge/level_scenarios.md § Entity Placement Record` and § Key Insights ("a 'scenario' needs almost no new abstraction"). The reference treats a level as a tiny geometry plus a flat list of entity-placement records, processed by exactly the same code path that loads any other level. This spec mirrors that shape: the generator returns the same `Level` struct that `level_data::build_default` returns, and `game_loop` cannot tell which builder produced it.
+
+## Architecture
+
+```
+specs/30 (autopilot)              specs/15 (this spec)
+        │                                 │
+        ▼                                 │
+   parse_scenario  ◀─────── adds optional `level: <name>` key
+        │                                 │
+        │                                 │
+   scenario.level.is_some()? ─yes─▶ level_generator::build(kind) ─▶ Level
+                                  │
+                                  └─no─▶ level_data::build_default() ─▶ Level
+
+                 Level ─▶ game_loop::new(level) ─▶ GameState ─▶ render loop
+```
+
+The generator is consumed only by `main.rs` after CLI argument parsing (specs/35 § CLI). It is NOT called from `game_loop::update`, NOT from any per-frame path, and NOT during interactive play. Once `game_loop::new(level)` has built the `GameState`, the runtime treats a generated demo level as just another `Level` — the same struct, the same coordinate system, the same `is_wall` boundary check, the same tick loop.
+
+## Demo Level Catalog
+
+The generator owns a small `DemoLevelKind` enum. Each variant maps to one builder function that returns a fully-populated `Level`. The `Level` type itself is unchanged (`ir/module_contracts.yaml § level_data.Level`, `specs/25 § Level Layout`) — same struct, same fields, same `Vec<Vec<Tile>>` grid, same `Vec<Pickup>`.
+
+| Variant | YAML name | Purpose | Implemented |
+|---------|-----------|---------|-------------|
+| `LocalChaseObstacle` | `local_chase_obstacle` | Demonstrates obstacle-aware enemy chase: one wall between player and enemy, valid path around. | yes |
+
+### LocalChaseObstacle
+
+**Purpose.** A short, visually clear demonstration that the basic-trooper enemy can navigate around a static obstacle to reach the player. The level reduces all visual clutter (no pickups, no extra walls, no irrelevant geometry) so the GIF reader's eye is drawn directly to the chase path.
+
+**Layout** (20 × 15 grid — same dimensions as the default level per `specs/25 § Level Layout`, so `GRID_WIDTH` / `GRID_HEIGHT` / `TILE_SIZE` from `level_data` apply unchanged):
+
+- All edges are walls (border): tiles at `x = 0`, `x = 19`, `y = 0`, `y = 14`.
+- Interior wall: a single vertical bar at `x = 10`, `y ∈ {4, 5, 6, 7, 8, 9, 10}` (7 tiles tall, vertically centered). This bar blocks the direct horizontal line between player and enemy.
+- All other interior tiles are floor.
+
+**Spawns** (tile units; same coordinate system as `level_data::Level::player_spawn` / `enemy_spawns` / `exit`):
+
+| Entity | Position | Rationale |
+|--------|----------|-----------|
+| Player spawn | `(3.5, 7.5)` | Left side, vertically centered. Faces the obstacle along the horizontal axis. |
+| Enemy spawn | `(16.5, 7.5)` | Right side, vertically centered. Mirrors the player so the obstacle sits exactly between them. |
+| Exit | `(1.5, 1.5)` | Far top-left corner, well away from the action. The bot's `kill: enemy` objective never directs it toward the exit, so the win-condition check (`player.pos.distance_to(level.exit) < EXIT_RADIUS`) is not triggered during the demo. |
+| Pickups | (none) | Empty `Vec<Pickup>`. Pickups would distract from the chase visualization. |
+
+**Path geometry.** The 7-tile-tall obstacle leaves two gaps:
+
+- A 3-tile-tall floor gap at the top: `y ∈ {1, 2, 3}` along the obstacle column (between the obstacle and the top border).
+- A 3-tile-tall floor gap at the bottom: `y ∈ {11, 12, 13}` along the obstacle column (between the obstacle and the bottom border).
+
+Either gap is wide enough for both the player (radius `0.4375` tile per `PLAYER_RADIUS_TILES`) and the enemy (radius `0.375` tile per `ENEMY_RADIUS_TILES`) to traverse with margin. The reference's chase routine (knowledge/level_scenarios.md § Obstacle-Aware Chase) prefers a direct diagonal toward the target; with the obstacle blocking that diagonal, the routine falls through to perpendicular alternates and then "continue old direction" — producing the characteristic "skim along the wall" path that this demo is meant to show.
+
+**Visual reading of the GIF.** With both player and enemy moving toward each other, the enemy hits the obstacle first (because the bot stops when it reaches firing range, while the enemy continues to close to contact range). The enemy then takes a perpendicular along the wall, rounds the corner at one of the gaps, and resumes the chase. The bot, separately, navigates around the same obstacle to close the distance for `kill: enemy`. The chase path is visible for several seconds before the engagement begins.
+
+## Scenario YAML Extension
+
+Scenarios opt into a non-default level by adding one optional key:
+
+```yaml
+scenario: local_chase_obstacle
+description: Enemy chases player around a wall, demonstrating obstacle-aware chase behavior
+level: local_chase_obstacle    # NEW — optional; absent = level_data::build_default()
+
+objectives:
+  - approach: enemy
+  - kill: enemy
+
+assertions:
+  - player.alive: true
+  - enemy.alive: false
+```
+
+**Field semantics:**
+
+- `level:` (string, optional). If present, names a `DemoLevelKind` variant in `snake_case` form (e.g. `LocalChaseObstacle` → `local_chase_obstacle`). If absent or null, the runtime constructs the default level via `level_data::build_default()`. Unknown names are a hard parse error: `parse_scenario` panics with a clear message naming the unknown variant and the list of accepted values, per `specs/30 § Execution Rules` ("`.expect("valid scenario YAML")`").
+- All existing fields (`scenario`, `description`, `objectives`, `assertions`) keep their existing semantics from `specs/30`.
+
+**Backwards compatibility.** Every existing scenario YAML in `tests/**/*.yaml` continues to work without modification — the `level:` field defaults to absent, which falls back to `level_data::build_default()`. Specifically:
+
+- `tests/combat/kill_enemy.yaml` — no `level:` field, uses default level.
+- `tests/level/complete_level.yaml` — no `level:` field, uses default level.
+- `tests/level/reach_exit.yaml` — no `level:` field, uses default level.
+- `tests/level/scavenge_run.yaml` — no `level:` field, uses default level.
+
+The parser change is purely additive: the field is `#[serde(default)]` on `Scenario` and the matching enum derives `serde::Deserialize` with `#[serde(rename_all = "snake_case")]`.
+
+## Module Boundaries
+
+The `level_generator` module sits between `level_data` (whose `Level` type it returns) and `main.rs` (its only consumer):
+
+- **Depends on:** `level_data` (for the `Level`, `Tile`, `Vec2`, `Pickup`, `PickupKind` types).
+- **Consumed by:** `main.rs` (loads the requested level when `--autopilot` mode parses a scenario with a `level:` field), and `autopilot` (the `DemoLevelKind` enum is a public type referenced by `Scenario.level: Option<DemoLevelKind>`). No other module references the generator.
+- **Not consumed by:** anything in the per-frame update path. Generation runs once, at startup, before the render loop begins. `game_loop::update`, `autopilot::bot_step`, `enemy_logic::update`, etc. never reference `level_generator`.
+
+This keeps the generator out of gameplay runtime logic per the issue's "Generator must not be part of gameplay runtime logic" constraint.
+
+### `game_loop::new` constructor signature
+
+To let `main.rs` choose between `level_data::build_default()` and `level_generator::build(kind)` without duplicating GameState construction logic, `game_loop::new()` is generalized to take a `Level` argument:
+
+```rust
+// before (specs/30 era):
+pub fn new() -> GameState                 // builds default level internally
+
+// after (this spec):
+pub fn new(level: Level) -> GameState     // caller chooses the level
+```
+
+`main.rs` is the sole caller; it picks the level based on `--autopilot` mode and the parsed scenario:
+
+```rust
+let level = match autopilot_scenario.as_ref().and_then(|s| s.level) {
+    Some(kind) => level_generator::build(kind),
+    None       => level_data::build_default(),
+};
+let mut game = game_loop::new(level);
+```
+
+Interactive play (no `--autopilot`) always passes `level_data::build_default()` — the `level:` scenario field has no effect on interactive play because no scenario is loaded. The combined `--autopilot --record-frames` invocation (the canonical PR-preview path) goes through the same `match` and picks the generated level when the scenario asks for it.
+
+## Determinism
+
+Determinism follows entirely from the rules already established in `specs/35 § Determinism`. The generator itself uses no randomness — each builder function is a pure function from `DemoLevelKind` to `Level`, so repeated calls return byte-equal `Level` structs. With:
+
+1. The fixed BGRA framebuffer recording (`specs/35 § Frame Recording Format`),
+2. The fixed `dt = 1/60` simulation step (`specs/35 § Determinism`),
+3. The fixed module-private RNG seeds in `--autopilot` mode (`specs/35 § Determinism`), and
+4. The pure-function builder defined here,
+
+a `--autopilot tests/level/local_chase_obstacle.yaml --record-frames out.raw` invocation produces a byte-identical `out.raw` across runs. This is the same property `specs/35 § Acceptance Criteria` already requires; this spec adds nothing to the determinism contract beyond "the builder is pure".
+
+## PR Preview Integration
+
+`tests/level/local_chase_obstacle.yaml` is the canonical PR-preview scenario. The split is:
+
+| Use case | Scenario | Level |
+|----------|----------|-------|
+| PR-preview GIF (visual demo) | `tests/level/local_chase_obstacle.yaml` | `local_chase_obstacle` (this spec) |
+| Regression `cargo test` runs | `tests/combat/*.yaml`, `tests/level/{complete_level,reach_exit,scavenge_run}.yaml` | default (`level_data::build_default`) |
+
+The default level (no `level:` field) remains the right choice for regression-style scenarios — they exercise the canonical level layout, the canonical pickup placements, and the canonical exit-reachability path. The demo level is purpose-built for visual clarity and would be a poor regression target (no pickups, single obstacle) but a strong PR-preview target.
+
+The spec asserts that the PR workflow's "Record gameplay GIF" step (`.github/workflows/pr.yml`) and `tooling/record_autopilot.sh`'s default scenario should both name `tests/level/local_chase_obstacle.yaml`. Updating those files is a workflow concern; see `work/pipeline_run_2026-05-03.md § Run-level follow-ups` for the maintainer task list (the agent-intake commit scope does not cover `.github/` or `tooling/` outside `tooling/agents/`, so the workflow swap ships separately).
+
+## Constraints
+
+- **No procedural generation.** Each demo level is a hand-written builder function. No grammar, no PCG seed, no algorithmic placement. Adding a new demo level means adding one enum variant and one function.
+- **`Level` representation is unchanged.** The generator returns the same `Level` struct that `level_data::build_default` returns. No new fields, no new tile types, no new entity records. (`ir/module_contracts.yaml § level_data.Level` is unmodified.)
+- **Generator is not part of gameplay runtime.** The only call sites are `main.rs` (once at startup) and the public `DemoLevelKind` type referenced by `autopilot::Scenario.level`. Per-frame paths never reference `level_generator`.
+- **Pure builder functions.** Each builder is a `fn(...) -> Level` with no I/O, no randomness, no global state. Repeated calls return byte-equal `Level` structs.
+- **Backwards compatible.** Scenarios without a `level:` field continue to use `level_data::build_default`. No existing test fixture is modified.
+
+## Implementation Status
+
+**Implemented:**
+- Spec defines the `DemoLevelKind` enum, the `level_generator::build` function, and the `LocalChaseObstacle` variant.
+- Spec defines the `level:` scenario YAML field and its fall-back semantics.
+- Spec defines the `game_loop::new(level: Level)` signature change and `main.rs`'s call-site decision.
+- Test fixture `tests/level/local_chase_obstacle.yaml` is authored alongside this spec.
+- IR module `level_generator` is added to `ir/module_plan.yaml` (universal-sink rule applied: `main.depends_on` lists `level_generator`).
+- IR contract for `level_generator` and the autopilot / `game_loop` extensions live in `ir/module_contracts.yaml`.
+
+**Deferred:**
+- Additional demo level variants beyond `LocalChaseObstacle` (e.g. corridor chase, multi-enemy fan-out, pickup-scavenge tutorial). Add a variant to `DemoLevelKind` and a builder function as the need arises.
+- Authoring fixtures for additional demo levels.
+- Allowing scenarios to override the default level's *contents* (e.g. a scenario that uses the default geometry but adds an extra enemy) — this would require either splitting `Level` into geometry-vs-entities or adding a separate "scenario overlay" concept. Not needed for the current PR-preview goal.
+- Workflow swap to use `tests/level/local_chase_obstacle.yaml` as the PR preview's recorded scenario (see `work/pipeline_run_2026-05-03.md § Run-level follow-ups`). The spec defines the integration target; the workflow file change ships in a maintainer follow-up because agent-intake's commit scope (`specs knowledge ir tooling/agents`) does not include `.github/workflows/` or `tooling/record_autopilot.sh`.
+
+## Related
+
+- `specs/30_test_framework.md` — autopilot scenario YAML format (this spec extends it with the optional `level:` field).
+- `specs/35_demo_mode.md` — `--autopilot` CLI mode and frame recording (this spec is consumed during scenario load in that mode).
+- `specs/25_game_tuning.md § Level Layout` — the default level's dimensions and layout (kept for backwards compatibility; this spec adds an alternative builder, not a replacement).
+- `knowledge/level_scenarios.md` — knowledge basis for "scenario = tiny geometry + entity list, hand-authored, no procedural generation" and the obstacle-aware chase behavior the demo level is designed to expose.
+- `ir/module_plan.yaml` — module-graph entry for `level_generator`.
+- `ir/module_contracts.yaml § level_generator` — the public API of the generator; § autopilot — the extended `Scenario` shape; § game_loop — the new `new(level)` signature.

--- a/specs/30_test_framework.md
+++ b/specs/30_test_framework.md
@@ -39,6 +39,7 @@ Scenarios are YAML files in `tests/` organized by area:
 ```yaml
 scenario: scenario_name
 description: Human-readable description
+level: local_chase_obstacle    # OPTIONAL — see specs/15. Absent = use default level.
 
 objectives:
   - kill: enemy
@@ -48,6 +49,8 @@ assertions:
   - player.alive: true
   - enemy.alive: false
 ```
+
+The `level:` field is optional. When present, it names a `DemoLevelKind` variant in `snake_case` form (currently only `local_chase_obstacle`); `main.rs` calls `level_generator::build(kind)` instead of `level_data::build_default()` to construct the scenario's level. When absent or null, the runtime uses the default level. See [`15_level_generator.md`](15_level_generator.md) for the catalog of demo levels and the layout details. Existing fixtures (`tests/combat/kill_enemy.yaml`, `tests/level/{complete_level,reach_exit,scavenge_run}.yaml`) omit the field and continue to use the default level.
 
 ## Objectives
 
@@ -134,6 +137,7 @@ If the bot's position hasn't changed for 30 frames, it begins strafing. After 60
 
 **Implemented:**
 - Scenario YAML format (`scenario`, `description`, `objectives`, `assertions` fields).
+- Optional `level:` field on Scenario (specs/15) — selects a generated demo level instead of `level_data::build_default()` when set; backwards compatible with all existing fixtures.
 - Objective types: `kill:`, `reach:`, `approach:`, `wait:`.
 - Target names: `enemy`, `exit`, `spawn`, `pickup_health`, `pickup_ammo` (with fallback semantics).
 - Assertion fields: `player.alive`, `player.health`, `enemy.alive`, `game.won`, `game.frames` — these five are implemented in `autopilot::eval_assertion`.
@@ -151,4 +155,5 @@ If the bot's position hasn't changed for 30 frames, it begins strafing. After 60
 
 ## Related
 
+- `specs/15_level_generator.md` — `DemoLevelKind` catalog and the optional `level:` scenario field.
 - `specs/35_demo_mode.md` — headed-autopilot CLI mode and frame recording for release demos.

--- a/specs/35_demo_mode.md
+++ b/specs/35_demo_mode.md
@@ -100,7 +100,12 @@ pub fn bot_step(
 
 ## Test Scenario Suitability for Demo
 
-Any scenario in `tests/**/*.yaml` is a valid demo input. The release process selects one scenario that produces the most visually informative recording — by default `tests/combat/kill_enemy.yaml` (movement + shooting + enemy death + visual feedback). Selection is a release-time choice, not a property of this spec.
+Any scenario in `tests/**/*.yaml` is a valid demo input. The release process selects one scenario that produces the most visually informative recording. Two canonical choices exist, picked at release-time:
+
+- **PR-preview GIF** (per-PR, on every push): `tests/level/local_chase_obstacle.yaml`. Uses the `local_chase_obstacle` demo level (specs/15) — a single vertical wall between player and enemy that forces the chase routine through priority-2 (perpendicular alternates) and priority-3 (continue old direction) of `knowledge/level_scenarios.md § Obstacle-Aware Chase`. The recorded GIF visibly answers "did the enemy navigate around the obstacle?" in a few seconds.
+- **Tagged-release GIF** (`release.yml`): `tests/level/scavenge_run.yaml`. Uses the default level — exercises movement + pickup pickup + combat + exit-reach in one run. Better suited for "tour of mechanics" than for any single behavior demo.
+
+Selection is a release-time choice, not a property of this spec; the spec asserts only that any `tests/**/*.yaml` scenario is a valid demo input. The PR-preview / release-gif split lives in `.github/workflows/{pr,release}.yml`.
 
 Demo recordings are intentionally short (< 10 seconds at 60 FPS = < 600 frames). The bot's `BOT_MAX_FRAMES` (3600) caps long runs; the recording script should also pass a soft duration budget.
 


### PR DESCRIPTION
Closes #6

Generated by `agent-intake.yml` run [#25253016369](https://github.com/RuslanMingaliev/worldsmith/actions/runs/25253016369).

Issue scope, usage stats, and the unified diff are attached as workflow artifacts.