### PR TITLE
docs(license): correct copyright header

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024-2026 Worldsmith contributors
+Copyright (c) 2026 Ruslan Mingaliev
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The previous header read `Copyright (c) 2024-2026 Worldsmith contributors`. The 2024 start year was fictional — the repo's first commit is 2026-04-04 — and "contributors" implied plural authorship that doesn't yet exist. Replaced with `Copyright (c) 2026 Ruslan Mingaliev`.

Earlier revisions of this PR also added a personal author note below the MIT block, separated by `---`. That regressed GitHub's license detection (`spdx_id` flipped from `MIT` to `NOASSERTION`), which would have broken the repo sidebar badge and any downstream license/dependency scanner that expects machine-readable MIT. The note was dropped from this PR; LICENSE is now strictly the canonical SPDX MIT body. If we want a personal foreword later, it goes into a separate file (AUTHOR_NOTE.md / README section / NOTICE), not LICENSE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)