### PR TITLE
feat(regen): make main.rs a first-class regen target

### DIFF
--- a/ir/module_plan.yaml
+++ b/ir/module_plan.yaml
@@ -67,3 +67,27 @@ modules:
       ffmpeg consumes the raw stream downstream.
     depends_on:
       - presentation
+
+  - name: main
+    responsibility: |
+      Binary entry point (generated/game/src/main.rs). Parses CLI flags
+      (--autopilot, --record-frames), declares `mod <name>;` for every
+      other module, constructs GameState, owns the main render loop.
+      Not gameplay logic — but contracted in ir/module_contracts.yaml
+      § main_cli, so spec edits that name main.rs (new CLI flag, new
+      module wiring) MUST regenerate it. Listing every other module in
+      depends_on makes partial_regen.py's reverse-dep closure pull main
+      in whenever any module is touched. validate_specs.py asserts the
+      list stays complete.
+    depends_on:
+      - level_data
+      - player_state
+      - input_controller
+      - visual_effects
+      - weapon_system
+      - enemy_logic
+      - presentation
+      - renderer
+      - game_loop
+      - autopilot
+      - frame_recorder

--- a/tooling/agents/architect.md
+++ b/tooling/agents/architect.md
@@ -27,6 +27,12 @@ Produce or update:
 - Spec files in `specs/`
 - IR files in `ir/`
 - Design notes in `work/`
+- **Test-fixture YAML files under `tests/`** when a spec references them by
+  filename (e.g. `tests/level/local_chase_obstacle.yaml`). Fixtures are part
+  of the spec — without them the Reconciler will mark the referenced spec
+  feature as deferred and the next Coder pass cannot wire the scenario
+  through. The Coder does not author these (its scope is `generated/`); if
+  you write a spec that names a fixture, you write the fixture too.
 
 ## Spec Writing Principles
 
@@ -97,6 +103,8 @@ modules:
 
 **Note:** `depends_on` is authoritative metadata. Keep it accurate because downstream tooling (partial regeneration planner, automation agents) rely on it to know which modules must be updated when specs change.
 
+**`main` is the universal sink.** When you add a new module to `module_plan.yaml`, also add its name to `main.depends_on`. `main` represents `generated/game/src/main.rs` (the binary entry point) and consumes every other module via `mod <name>;` declarations. Forgetting to update `main.depends_on` creates a silent gap: the new module would regenerate without `main.rs` being re-emitted to declare it, and the file ships orphaned (PR #10's `level_generator.rs` failure mode). `tooling/validate_specs.py § validate_module_plan` enforces this invariant — adding a module without updating `main.depends_on` will fail the validator.
+
 ## Quality Checklist
 
 Before submitting:
@@ -108,6 +116,8 @@ Before submitting:
 - [ ] Every spec has an `Implementation Status` section with both Implemented and Deferred buckets populated
 - [ ] No dangling cross-references (e.g. "see ADR N" must point to an existing decision)
 - [ ] Every spec rule that EXPLICITLY contradicts a knowledge entry (e.g. spec uses circle distance where knowledge uses AABB; spec hardcodes a value where knowledge reads from asset; spec applies a coloring policy that knowledge says the reference does NOT do) is flagged at the rule site with an inline `*(Generation default — knowledge says X; we use Y because <rationale>.)*` AND surfaced to the run journal under `### ADR candidates` for the PostMortem to elevate. Rationale: deviations that accumulate unflagged become future re-extraction questions the journal-only parking lot will lose. See `tooling/agents/postmortem.md` for the elevation pipeline.
+- [ ] If you added a new module to `ir/module_plan.yaml`, you also added its name to `main.depends_on`. `tooling/validate_specs.py` will fail otherwise.
+- [ ] If a new or modified spec names a `tests/**/*.yaml` fixture file, the fixture is authored alongside the spec — Coder will not create it.
 
 ## Escalation
 

--- a/tooling/agents/coder.md
+++ b/tooling/agents/coder.md
@@ -110,10 +110,16 @@ When you see such a scope override:
 
 - Read specs / knowledge / IR for full context, but **only write to**
   `generated/game/src/<module>.rs` for modules in the listed set.
-- Do **not** touch other module files, `main.rs`, or `Cargo.toml`. The harness
-  snapshots `generated/game/src/` before you run and machine-reverts any
-  out-of-scope edits afterward — spending tokens on those files is pure waste,
-  and the revert will silently undo your work.
+- `main` is a regular module name in this scope model: when it appears in
+  the listed set, you write to `generated/game/src/main.rs`. It contracts
+  CLI flag parsing, `mod <name>;` declarations, and the render loop (see
+  `ir/module_contracts.yaml § main_cli`). When `main` is NOT in the listed
+  set, you do not edit `main.rs` — same rule as any other out-of-scope
+  module.
+- Do **not** touch module files outside the listed set or `Cargo.toml`. The
+  harness snapshots `generated/game/src/` before you run and machine-reverts
+  any out-of-scope edits afterward — spending tokens on those files is pure
+  waste, and the revert will silently undo your work.
 - If a listed module's spec implies a contract change for a non-listed module
   (signature change, new shared type, etc.), STOP and write a blocker note to
   `artifacts/blocker.md` describing the contract delta. Do not silently

--- a/tooling/agents/reconciler.md
+++ b/tooling/agents/reconciler.md
@@ -35,7 +35,9 @@ Triage the diff:
 - `dead_code` on a `pub` symbol that is dead in BOTH builds → unconditional dead export. Spec/80 § API Surface violation.
 - `unused_imports` referencing constants from `visual_effects`, `player_state`, etc. → the importing module gave up on a behavior the spec called for.
 
-Only proceed to Step 1 once warnings have been triaged into "spec drift" / "cfg-test-only / needs gate" / "expected wave-cascade noise" buckets and recorded in the report.
+**Orphan file check.** A clean `cargo build` is **not** sufficient — rustc only compiles what `main.rs` declares with `mod <name>;`. After triaging warnings, list `generated/game/src/*.rs` and confirm every file (other than `main.rs`) has a matching `mod` declaration. If a file is on disk but unreferenced, rustc silently skips it: zero warnings, but also zero compiled tests, and the public API is dead. Flag every orphan in `### Drift found` with the `mod` line that's missing. The mechanical complement is `tooling/check_orphan_files.py`, invoked by `validate_specs.py`; this Step 0 bullet is the agent-side guard for the case where a Coder ships a new module-file but leaves `main.rs` out of scope (PR #10).
+
+Only proceed to Step 1 once warnings have been triaged into "spec drift" / "cfg-test-only / needs gate" / "expected wave-cascade noise" / "orphan-file" buckets and recorded in the report.
 
 ### Step 1: Scan code for constants
 

--- a/tooling/check_orphan_files.py
+++ b/tooling/check_orphan_files.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""
+Orphan-file check.
+
+Every `*.rs` in `generated/game/src/` (other than `main.rs`) must have a
+matching `mod <stem>;` declaration in `main.rs`. An orphan file is silently
+omitted from the crate by rustc: zero warnings, zero compiled tests, but
+the file ships in the release artifact and any human reading it would
+assume it's wired up.
+
+Background: in PR #10's regen pass the Coder correctly created
+`generated/game/src/level_generator.rs` and wrote a blocker note when
+`main.rs` turned out to be outside its --target-modules scope; the file
+was therefore never declared. `cargo build` was clean, `cargo test`
+reported 45 passing — and 7 tests inside `level_generator.rs` silently
+skipped. Reconciler caught it manually by `ls`-ing the dir and grepping
+`main.rs`. This script makes that check mechanical.
+
+Exit 0 if no orphans (or `generated/` doesn't exist yet), exit 1 with the
+list otherwise.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = REPO_ROOT / "generated" / "game" / "src"
+MAIN_RS = SRC_DIR / "main.rs"
+
+MOD_DECL = re.compile(r"^\s*(?:pub\s+)?mod\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*;", re.MULTILINE)
+
+
+def find_orphans() -> list[str]:
+    if not SRC_DIR.is_dir() or not MAIN_RS.is_file():
+        return []
+    declared = set(MOD_DECL.findall(MAIN_RS.read_text(encoding="utf-8")))
+    on_disk = {p.stem for p in SRC_DIR.glob("*.rs") if p.name != "main.rs"}
+    return sorted(on_disk - declared)
+
+
+def main() -> int:
+    orphans = find_orphans()
+    if not orphans:
+        return 0
+    print(
+        f"Orphan files in {SRC_DIR.relative_to(REPO_ROOT)} "
+        f"(present on disk but not declared in main.rs):",
+        file=sys.stderr,
+    )
+    for stem in orphans:
+        print(f"  - {stem}.rs (missing `mod {stem};` in main.rs)", file=sys.stderr)
+    print(
+        "\nThe compiler will silently skip these files. Any unit tests "
+        "inside them will not run. Add `mod <name>;` to main.rs or delete "
+        "the orphan.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tooling/partial_regen.py
+++ b/tooling/partial_regen.py
@@ -69,6 +69,18 @@ TRIGGER_CONFIG = {
         "autopilot": [
             "specs/30_test_framework.md",
             "tests/**",
+            # specs/15 § Scenario.level: autopilot.Scenario gains an optional
+            # `level` field referencing crate::level_generator::DemoLevelKind.
+            "specs/15_level_generator.md",
+            "knowledge/level_scenarios.md",
+        ],
+        "level_generator": [
+            # specs/15 owns the demo-level builder. Trigger fires once
+            # level_generator joins ir/module_plan.yaml (added by an Architect
+            # pass). Until then, `if module not in known_modules: continue`
+            # in determine_modules() filters this row out — harmless.
+            "specs/15_level_generator.md",
+            "knowledge/level_scenarios.md",
         ],
         "level_data": [
             # specs/60 § Pickup Entity: Pickup type + pickups field live here.

--- a/tooling/validate_specs.py
+++ b/tooling/validate_specs.py
@@ -120,6 +120,8 @@ def validate_module_plan(path: Path) -> List[ValidationIssue]:
         return [ValidationIssue(path, "`modules` must be a non-empty list.")]
 
     seen_names = set()
+    main_depends_on: List[str] = []
+    main_present = False
     for idx, module in enumerate(modules):
         if not isinstance(module, dict):
             issues.append(
@@ -145,6 +147,43 @@ def validate_module_plan(path: Path) -> List[ValidationIssue]:
             issues.append(
                 ValidationIssue(
                     path, f"modules[{idx}] missing string `responsibility`."
+                )
+            )
+
+        if name == "main":
+            main_present = True
+            deps = module.get("depends_on", []) or []
+            if isinstance(deps, list):
+                main_depends_on = [d for d in deps if isinstance(d, str)]
+
+    # If `main` is in the plan, it must list every other module in depends_on.
+    # Rationale: partial_regen.py's reverse-dep closure relies on main being a
+    # universal sink so any triggered module pulls main into the regen scope.
+    # Forgetting to add a new module to main.depends_on creates a silent gap
+    # — the new module would regenerate without main.rs being re-emitted to
+    # declare it, reproducing the orphan-file bug from PR #10. This invariant
+    # makes that mistake a hard validation error.
+    if main_present:
+        expected = seen_names - {"main"}
+        listed = set(main_depends_on)
+        missing = expected - listed
+        extra = listed - expected
+        if missing:
+            issues.append(
+                ValidationIssue(
+                    path,
+                    f"main.depends_on is missing modules: {sorted(missing)}. "
+                    f"main is the universal sink in partial_regen.py's "
+                    f"reverse-dep closure; every module must be listed.",
+                )
+            )
+        if extra:
+            issues.append(
+                ValidationIssue(
+                    path,
+                    f"main.depends_on lists unknown modules: {sorted(extra)}. "
+                    f"Either add the module to ir/module_plan.yaml or remove "
+                    f"the entry from main.depends_on.",
                 )
             )
 
@@ -270,6 +309,7 @@ def validate_reference_knowledge_integrity() -> List[ValidationIssue]:
 # pass the gate clean).
 
 CHECK_SANITIZATION_SCRIPT = REPO_ROOT / "tooling" / "check_sanitization.py"
+CHECK_ORPHAN_FILES_SCRIPT = REPO_ROOT / "tooling" / "check_orphan_files.py"
 
 
 def _run_sanitization(paths: Sequence[Path]) -> int:
@@ -331,6 +371,35 @@ def validate_knowledge_sanitization() -> List[ValidationIssue]:
     return []
 
 
+def validate_orphan_files() -> List[ValidationIssue]:
+    """Run the orphan-file gate over generated/game/src/.
+
+    A `*.rs` file in src/ that has no matching `mod <name>;` in main.rs is
+    silently omitted from the crate by rustc — zero warnings, zero compiled
+    tests. The Reconciler agent learned to flag this manually after PR #10;
+    this is the mechanical complement.
+    """
+    if not CHECK_ORPHAN_FILES_SCRIPT.exists():
+        return []
+    result = subprocess.run(
+        [sys.executable, str(CHECK_ORPHAN_FILES_SCRIPT)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.stderr:
+        print(result.stderr, file=sys.stderr, end="")
+    if result.returncode == 0:
+        return []
+    return [
+        ValidationIssue(
+            REPO_ROOT / "generated" / "game" / "src",
+            "orphan source files present — see tooling/check_orphan_files.py "
+            "output above.",
+        )
+    ]
+
+
 def parse_arguments() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Validate specs, knowledge, and IR files."
@@ -353,6 +422,7 @@ def main() -> None:
     issues.extend(validate_module_plan(REPO_ROOT / "ir" / "module_plan.yaml"))
     issues.extend(validate_reference_knowledge_integrity())
     issues.extend(validate_knowledge_sanitization())
+    issues.extend(validate_orphan_files())
 
     if issues:
         print("Validation failed:", file=sys.stderr)


### PR DESCRIPTION
Closes the structural gap that caused PR #10's `level_generator.rs` to ship orphaned. `tooling/partial_regen.py § determine_modules` filters affected modules by `known_modules` (the names from `ir/module_plan.yaml`), so `main` could never appear in `--target-modules` even though `ir/module_contracts.yaml § main_cli` contracts edits to `main.rs`. Adding `main` as a module entry — with `depends_on` listing every other module — makes the reverse-dep closure pull `main` into scope whenever any module is triggered. `main` itself is a sink (nothing depends on it), so the closure terminates cleanly without bloating small triggers.

Empirical verification on this branch:

- `specs/50_hud.md` → was `[renderer]`, now `[main, renderer]`.
- `specs/60_pickups.md` → was 11 modules, now 12 (adds `main`).
- `specs/15_level_generator.md` → `[autopilot, main]` (and will become `[autopilot, level_generator, main]` once issue #6's PR re-runs and adds `level_generator` to `module_plan.yaml`).
- `specs/30_test_framework.md` → was `[autopilot]`, now `[autopilot, main]`.

The dependency-expansion loop in `partial_regen.py` walks reverse-deps, so the worry «if `main.depends_on = [<all>]` then any trigger explodes into a full regen» does not materialize. Confirmed by running the planner on every per-module spec.

`validate_specs.py § validate_module_plan` gains an invariant: if `main` is in the plan, `main.depends_on` must equal `{all other modules}`. The next time someone adds a module without updating `main`'s deps, the validator fails with a concrete diff. Negative-tested locally.

`tooling/check_orphan_files.py` is a new mechanical gate: every `*.rs` in `generated/game/src/` (other than `main.rs`) must have a matching `mod <name>;` in `main.rs`. An orphan file is invisible to rustc — zero warnings, zero compiled tests, but the file ships. PR #10's `level_generator.rs` was exactly this. The script is wired into `validate_specs.py`, and `tooling/agents/reconciler.md § Step 0` gains an orphan-check bullet so the Reconciler agent flags the same invariant in its report.

`tooling/agents/coder.md § Partial regeneration mode` notes that `main` is now a regular target name — when listed, Coder writes `main.rs`; when not listed, it's out of scope like any other module.

`tooling/agents/architect.md` gains two Quality Checklist items: (a) update `main.depends_on` whenever a module is added, (b) author `tests/**/*.yaml` fixtures alongside specs that reference them (since Coder's write scope is `generated/` only — observed gap from PR #10 where `tests/level/local_chase_obstacle.yaml` was named in spec/15 but never created).

Once this lands, re-applying `agent:run` to issue #6 will trigger the agent-intake's `git checkout -B agent/issue-6` from this updated `main`, force-push, and `pr.yml` will run Coder/Reconciler/PostMortem with `main` in scope. The expected delta in the next PR-10-replacement: `cargo test` reports 52 passing (was 45; the 7 silently-skipped `level_generator.rs` tests now run), `reconciler_report.md § Drift found` is empty, and the demo GIF actually shows the LocalChaseObstacle scenario — closing the acceptance criterion from issue #6.