### PR TITLE
release: swap PR-preview demo to local_chase_obstacle scenario

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -199,7 +199,7 @@ jobs:
         run: |
           set -e
           mkdir -p release
-          xvfb-run -a tooling/record_autopilot.sh tests/level/scavenge_run.yaml release/demo.gif
+          xvfb-run -a tooling/record_autopilot.sh tests/level/local_chase_obstacle.yaml release/demo.gif
           ls -la release/
 
       - name: Push demo GIF to shared pr-assets branch (for inline embed)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -290,7 +290,7 @@ jobs:
       - name: Record demo (linux only)
         run: |
           mkdir -p release
-          xvfb-run -a tooling/record_autopilot.sh tests/level/scavenge_run.yaml release/demo.gif
+          xvfb-run -a tooling/record_autopilot.sh tests/level/local_chase_obstacle.yaml release/demo.gif
 
       - name: Package src zip + demo GIF
         env:

--- a/ir/module_plan.yaml
+++ b/ir/module_plan.yaml
@@ -1,3 +1,7 @@
+# Demo recording (pr.yml + release.yml) switched from scavenge_run to
+# local_chase_obstacle as of this commit; touching this file forces a
+# global regen so the new fixture is exercised end-to-end on the
+# triggering PR rather than on the next release.
 modules:
   - name: level_data
     responsibility: static map and spawn positions

--- a/specs/15_level_generator.md
+++ b/specs/15_level_generator.md
@@ -168,15 +168,15 @@ The spec asserts that the PR workflow's "Record gameplay GIF" step (`.github/wor
 - Spec defines the `DemoLevelKind` enum, the `level_generator::build` function, and the `LocalChaseObstacle` variant.
 - Spec defines the `level:` scenario YAML field and its fall-back semantics.
 - Spec defines the `game_loop::new(level: Level)` signature change and `main.rs`'s call-site decision.
-- Test fixture `tests/level/local_chase_obstacle.yaml` is authored alongside this spec.
+- Test fixture `tests/level/local_chase_obstacle.yaml` exists on disk and uses the `level: local_chase_obstacle` field plus the `approach: enemy` / `kill: enemy` objectives.
 - IR module `level_generator` is added to `ir/module_plan.yaml` (universal-sink rule applied: `main.depends_on` lists `level_generator`).
 - IR contract for `level_generator` and the autopilot / `game_loop` extensions live in `ir/module_contracts.yaml`.
+- `.github/workflows/pr.yml` and `.github/workflows/release.yml` record the demo GIF using `tests/level/local_chase_obstacle.yaml` as the canonical PR-preview scenario.
 
 **Deferred:**
 - Additional demo level variants beyond `LocalChaseObstacle` (e.g. corridor chase, multi-enemy fan-out, pickup-scavenge tutorial). Add a variant to `DemoLevelKind` and a builder function as the need arises.
 - Authoring fixtures for additional demo levels.
 - Allowing scenarios to override the default level's *contents* (e.g. a scenario that uses the default geometry but adds an extra enemy) — this would require either splitting `Level` into geometry-vs-entities or adding a separate "scenario overlay" concept. Not needed for the current PR-preview goal.
-- Workflow swap to use `tests/level/local_chase_obstacle.yaml` as the PR preview's recorded scenario (see `work/pipeline_run_2026-05-03.md § Run-level follow-ups`). The spec defines the integration target; the workflow file change ships in a maintainer follow-up because agent-intake's commit scope (`specs knowledge ir tooling/agents`) does not include `.github/workflows/` or `tooling/record_autopilot.sh`.
 
 ## Related
 

--- a/tests/level/local_chase_obstacle.yaml
+++ b/tests/level/local_chase_obstacle.yaml
@@ -1,0 +1,11 @@
+scenario: local_chase_obstacle
+description: Enemy chases player around a wall, demonstrating obstacle-aware chase behavior
+level: local_chase_obstacle
+
+objectives:
+  - approach: enemy
+  - kill: enemy
+
+assertions:
+  - player.alive: true
+  - enemy.alive: false


### PR DESCRIPTION
Maintainer follow-up to PR #10 (issue #6). The `level_generator` infrastructure shipped, but spec/15 § Implementation Status § Deferred explicitly punted the workflow-swap and the test-fixture file because agent-intake's commit scope excludes both `.github/workflows/` and `tests/`. This PR closes both items.

Diff:
- `tests/level/local_chase_obstacle.yaml` (new) — uses `level: local_chase_obstacle` and the new `approach: enemy` / `kill: enemy` objectives from spec/30.
- `.github/workflows/pr.yml:202` and `.github/workflows/release.yml:293` swap `tests/level/scavenge_run.yaml` → `tests/level/local_chase_obstacle.yaml`.
- `specs/15_level_generator.md` § Implementation Status moves the workflow-swap bullet from Deferred to Implemented and rewrites the fixture bullet (the file is now on disk; previously it was Architect-promised but excluded from the agent-intake commit).
- `ir/module_plan.yaml` gains a leading comment so this PR triggers `partial_regen.py § global` and forces a full regen.

The global-trigger touch is load-bearing. Without it, regen-and-build would baseline from `2026.02` (pre-issue-#6, no `level_generator.rs`) and try to partial-regen `autopilot` + `main`. `autopilot.rs` would fail to compile because `crate::level_generator::DemoLevelKind` would be unresolved. Full regen materializes `level_generator` from spec/15 against the same baseline, then wires it through `autopilot` and `main` — the same path PR #10 v2 took, which is known-working.

The point of forcing the regen on this PR rather than on the next release is to record the demo GIF using the new fixture **before merge**. Issue #6's acceptance criterion is "PR preview GIF clearly shows enemy navigating around obstacle"; the GIF in this PR's status comment is the empirical validation. Knowledge/level_scenarios.md § Obstacle-Aware Chase claims the existing 8-direction chase reselection (priority-1 diagonal blocked → priority-2 perpendicular → priority-3 continue-old-direction "skim along the wall") produces obstacle-aware navigation without explicit pathfinding. The bot's `approach: enemy` objective completes at distance 8 (west of the wall, no navigation needed), so the visual is enemy navigation, not bot navigation — exactly what the acceptance asks for. The bot's subsequent `kill: enemy` phase is where bot-side stuck-detection has to fire; if the GIF shows the bot getting wedged, this PR doesn't merge.

Verification commands run locally before push: `python3 tooling/validate_specs.py --verbose` (green); `python3 tooling/partial_regen.py --changed ir/module_plan.yaml --json` returns all 13 modules (global trigger confirmed).