### PR TITLE
release: LLM-authored hero pitch and what's-new prose

### DIFF
--- a/.github/release-notes.template.md
+++ b/.github/release-notes.template.md
@@ -1,6 +1,6 @@
 {{HERO_PITCH}}
 
-![gameplay](https://github.com/RuslanMingaliev/worldsmith/releases/download/{{VERSION}}/worldsmith-{{VERSION}}-gameplay.gif)
+![Worldsmith {{VERSION}} gameplay](https://github.com/RuslanMingaliev/worldsmith/releases/download/{{VERSION}}/worldsmith-{{VERSION}}-gameplay.gif)
 
 ## What's new since {{PREV_VERSION}}
 
@@ -8,7 +8,7 @@
 
 ## Try it
 
-Download a binary for your platform from **Assets** below, unpack, run.
+Download a binary for your platform from the assets list below this release page, unpack, run.
 Or build from source:
 
 ```bash
@@ -19,28 +19,18 @@ cargo run --release
 
 `W A S D` move · arrows turn · space fire · ESC quit. Reach the cyan **X**.
 
-## Inside the build
-
-- **{{MODULE_COUNT}} modules**, ~{{LOC}} lines of Rust. {{TEST_SUMMARY}}
-- Built with `{{RUSTC_VERSION}}`, edition 2024, dependency: `minifb` (window + framebuffer).
-- The source archive (`worldsmith-game-{{VERSION}}-src.zip`) is the artifact; the specs at this tag are the source of truth. Regenerating from `specs/` + `ir/` should produce equivalent code (architecture identical; LLM-generated whitespace and comments may vary).
-
 ## Read it
 
-This is a spec-driven game. The Rust code is regenerable; the **specs** are what's actually maintained.
+This is a spec-driven game. The Rust code is regenerable; the **specs** are what's actually maintained. Regenerating from `specs/` + `ir/` at this tag should produce equivalent code (architecture identical; LLM-generated whitespace and comments may vary).
 
 - [`specs/`](https://github.com/RuslanMingaliev/worldsmith/tree/{{VERSION}}/specs) — gameplay model, tuning, generation rules.
 - [`knowledge/`](https://github.com/RuslanMingaliev/worldsmith/tree/{{VERSION}}/knowledge) — sanitized findings extracted from reference material.
 - [`tooling/agents/`](https://github.com/RuslanMingaliev/worldsmith/tree/{{VERSION}}/tooling/agents) — the prompts that generated this code.
-- `worldsmith-{{VERSION}}-postmortem.md` (release asset) — full agent-pipeline post-mortem: what worked, what hurt, what to fix next time.
+- [`worldsmith-{{VERSION}}-postmortem.md`](https://github.com/RuslanMingaliev/worldsmith/releases/download/{{VERSION}}/worldsmith-{{VERSION}}-postmortem.md) — full agent-pipeline post-mortem: what worked, what hurt, what to fix next time.
 
-## Assets
+## Stats
 
-{{ASSET_TABLE}}
-
-## Known limitations
-
-See `specs/`'s § Deferred sections at this tag for the full deferred-features list.
+**{{MODULE_COUNT}} modules** · ~{{LOC}} lines of Rust · {{TEST_SUMMARY}} · `{{RUSTC_VERSION}}`, edition 2024 · single dependency: `minifb` (window + framebuffer).
 
 <details>
 <summary>Generation report (token usage, post-mortem highlights)</summary>

--- a/.github/release-notes.template.md
+++ b/.github/release-notes.template.md
@@ -1,28 +1,51 @@
-Tagged generated sample of the retro shooter. The whole `generated/game/` tree was regenerated end-to-end from the specs on {{GENERATED_AT}} via the multi-agent pipeline (Architect contracts pass → Coder waves → Reconciler → PostMortem).
+{{HERO_PITCH}}
 
 ![gameplay](https://github.com/RuslanMingaliev/worldsmith/releases/download/{{VERSION}}/worldsmith-{{VERSION}}-gameplay.gif)
 
-## What's in this build
+## What's new since {{PREV_VERSION}}
 
-- {{MODULE_COUNT}} modules, ~{{LOC}} lines of Rust
-- {{TEST_SUMMARY}}
-- Built with `{{RUSTC_VERSION}}`, edition 2024, dependency: `minifb` (window + framebuffer)
+{{WHATSNEW_PROSE}}
 
-## Controls
+## Try it
 
-`W A S D` move · arrows turn · space fire · ESC quit.
+Download a binary for your platform from **Assets** below, unpack, run.
+Or build from source:
+
+```bash
+unzip worldsmith-game-{{VERSION}}-src.zip
+cd worldsmith-game-{{VERSION}}
+cargo run --release
+```
+
+`W A S D` move · arrows turn · space fire · ESC quit. Reach the cyan **X**.
+
+## Inside the build
+
+- **{{MODULE_COUNT}} modules**, ~{{LOC}} lines of Rust. {{TEST_SUMMARY}}
+- Built with `{{RUSTC_VERSION}}`, edition 2024, dependency: `minifb` (window + framebuffer).
+- The source archive (`worldsmith-game-{{VERSION}}-src.zip`) is the artifact; the specs at this tag are the source of truth. Regenerating from `specs/` + `ir/` should produce equivalent code (architecture identical; LLM-generated whitespace and comments may vary).
+
+## Read it
+
+This is a spec-driven game. The Rust code is regenerable; the **specs** are what's actually maintained.
+
+- [`specs/`](https://github.com/RuslanMingaliev/worldsmith/tree/{{VERSION}}/specs) — gameplay model, tuning, generation rules.
+- [`knowledge/`](https://github.com/RuslanMingaliev/worldsmith/tree/{{VERSION}}/knowledge) — sanitized findings extracted from reference material.
+- [`tooling/agents/`](https://github.com/RuslanMingaliev/worldsmith/tree/{{VERSION}}/tooling/agents) — the prompts that generated this code.
+- `worldsmith-{{VERSION}}-postmortem.md` (release asset) — full agent-pipeline post-mortem: what worked, what hurt, what to fix next time.
 
 ## Assets
 
 {{ASSET_TABLE}}
 
-## Reproducibility
+## Known limitations
 
-This is a "generated sample". The source archive is the artifact; specs at this tag are the source of truth. Regenerating from `specs/` + `ir/` should produce equivalent code (architecture identical; LLM-generated whitespace/comments may vary).
+See `specs/`'s § Deferred sections at this tag for the full deferred-features list.
 
-## Generation report
+<details>
+<summary>Generation report (token usage, post-mortem highlights)</summary>
 
-Pipeline run via the `release.yml` GitHub Actions workflow.
+Generated end-to-end from `specs/` on {{GENERATED_AT}} via the multi-agent pipeline (Architect contracts pass → Coder → Reconciler → PostMortem → Release Editor).
 
 ### Token usage
 
@@ -32,6 +55,4 @@ Pipeline run via the `release.yml` GitHub Actions workflow.
 
 {{POSTMORTEM_SUMMARY}}
 
-## Known limitations
-
-See `specs/` directory at this tag for the deferred-features list.
+</details>

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -269,6 +269,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install --no-install-recommends -y xvfb ffmpeg
 
+      - name: Install Claude CLI (for release_editor phase)
+        run: |
+          curl -fsSL https://claude.ai/install.sh | bash
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
       - name: Download generation artifacts
         uses: actions/download-artifact@v4
         with:
@@ -323,15 +328,61 @@ jobs:
           print(manifest)
           PY
 
+      - name: Determine previous release tag
+        id: prev_tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -e
+          # Pick the most recent existing release tag (excluding the version
+          # being created right now, in case a previous attempt left a draft).
+          PREV=$(gh release list --exclude-drafts --limit 5 \
+                  --json tagName --jq ".[] | select(.tagName != \"$VERSION\") | .tagName" \
+                  | head -n1)
+          if [ -z "$PREV" ]; then
+            # Fallback: nearest annotated tag in git history excluding HEAD itself.
+            PREV=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
+          fi
+          echo "Previous release tag: ${PREV:-(none)}"
+          echo "tag=$PREV" >> "$GITHUB_OUTPUT"
+
+      - name: Author release narrative (hero pitch + what's new prose)
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+          PREV_TAG: ${{ steps.prev_tag.outputs.tag }}
+        run: |
+          set -e
+          if [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]; then
+            echo "::warning::CLAUDE_CODE_OAUTH_TOKEN not set; skipping release_editor (release notes will use fallback placeholders)."
+            exit 0
+          fi
+          if [ -z "${PREV_TAG:-}" ]; then
+            echo "::warning::Could not determine previous release tag; release_editor will use git fallback."
+          fi
+          # The agent reads previous_tag/current_tag from the scope override.
+          # Failure here is non-fatal (fallback placeholders ship in compose).
+          python tooling/orchestrator_run.py \
+            --mode release \
+            --phase release_editor \
+            --scope "previous_tag: ${PREV_TAG:-(unknown)}; current_tag: ${VERSION}" \
+            || echo "::warning::release_editor phase failed; release notes will use fallback placeholders."
+
       - name: Compose release notes
         env:
           VERSION: ${{ inputs.version }}
+          PREV_TAG: ${{ steps.prev_tag.outputs.tag }}
         run: |
           python tooling/compose_release_notes.py \
             --version "$VERSION" \
+            --prev-version "${PREV_TAG:-unknown}" \
             --usage-jsonl artifacts/usage.jsonl \
             --postmortem artifacts/postmortem.md \
             --manifest artifacts/manifest.json \
+            --release-hero artifacts/release_hero.md \
+            --release-whatsnew artifacts/release_whatsnew.md \
             --assets-dir assets \
             --out artifacts/release-notes.md
 

--- a/tooling/agents/release_editor.md
+++ b/tooling/agents/release_editor.md
@@ -31,13 +31,13 @@ Answer: "what happened in this release, and why does the reader care". Plainspok
 
 ### `artifacts/release_whatsnew.md`
 
-A bulleted "What's new" list. One bullet per merged PR that ships user-facing or process-facing change. **Drop housekeeping/nit PRs that don't move gameplay, generation pipeline, or release process.** Format each bullet:
+A bulleted "What's new" list. One bullet per merged PR that ships user-facing or process-facing change. **Drop housekeeping/nit PRs that don't move gameplay, generation pipeline, or release process.** Format each bullet with a clickable PR link:
 
 ```
-- **#NN — Bold headline (4–8 words)** — One or two sentences expanding into concrete impact. Cite spec/section if applicable.
+- **[#NN](https://github.com/RuslanMingaliev/worldsmith/pull/NN) — Bold headline (4–8 words)** — One or two sentences expanding into concrete impact. Cite spec/section if applicable.
 ```
 
-Order by impact, not chronology. If 6+ bullets remain after dropping nits, group into thematic sub-sections (`### Gameplay`, `### Pipeline`, `### Release process`).
+Substitute the actual PR number into both the link text and the URL. Order bullets by impact, not chronology. If 6+ bullets remain after dropping nits, group into thematic sub-sections (`### Gameplay`, `### Pipeline`, `### Release process`).
 
 ## Constraints
 
@@ -56,7 +56,7 @@ Order by impact, not chronology. If 6+ bullets remain after dropping nits, group
 
 **Bad bullet:** "- **#15 — release: swap PR-preview demo to local_chase_obstacle scenario** — This PR swaps the demo."
 
-**Good bullet:** "- **#15 — Demo records on the obstacle scenario** — PR-preview and release demo GIFs now use `tests/level/local_chase_obstacle.yaml`, demonstrating the new level generator (`spec/15`) end-to-end. The first 4 seconds of the GIF visibly show the enemy navigating around the wall."
+**Good bullet:** "- **[#15](https://github.com/RuslanMingaliev/worldsmith/pull/15) — Demo records on the obstacle scenario** — PR-preview and release demo GIFs now use `tests/level/local_chase_obstacle.yaml`, demonstrating the new level generator (`spec/15`) end-to-end. The first 4 seconds of the GIF visibly show the enemy navigating around the wall."
 
 ## Failure modes
 

--- a/tooling/agents/release_editor.md
+++ b/tooling/agents/release_editor.md
@@ -1,0 +1,65 @@
+# Release Editor Agent
+
+## Role
+
+You author the public-facing release notes for a worldsmith release. You are a copy editor with a deep read of what shipped — not a marketer, not a developer.
+
+## Inputs you should read
+
+You are given:
+
+- `artifacts/postmortem.md` — the agent pipeline's post-mortem of THIS release's regen pass. Internal-leaning, but a useful source for "what was hard / what to flag".
+- `artifacts/manifest.json` — module count, LoC, test summary, rustc version, generation date.
+- `git log --merges --pretty='format:%H %s' <prev_tag>..HEAD` — merge commits between the previous tag and HEAD. Each merge usually corresponds to a PR.
+- For each merge line `Merge pull request #N from ...`, run `gh pr view N --json title,body,number,labels,closingIssuesReferences` to get the PR title, body, and any linked issues. The body usually contains the intent (Goal / Scope / etc.).
+- Optionally `git diff <prev_tag>..HEAD -- specs/` to verify a PR's claim against spec changes.
+
+The previous tag comes via the `## Scope override` block at the top of this prompt (key `previous_tag`). If missing, use `git describe --tags --abbrev=0 HEAD^` as a fallback.
+
+## What to write
+
+Exactly two files in `artifacts/`:
+
+### `artifacts/release_hero.md`
+
+The top-of-page elevator. Plain markdown. Pick the form that fits the release content:
+
+- **1–3 short paragraphs** if the release has one or two narrative threads.
+- **A short bulleted list (≤5 items)** if the release has multiple parallel drops with no single thread.
+
+Answer: "what happened in this release, and why does the reader care". Plainspoken indie-developer tone. No marketing buzzwords ("revolutionary", "leveraging", "powered by AI"). Cite spec sections when you make a feature claim (`spec/15`, `spec/50`) so readers can drill in. Do not start with the version number — the version is already in the title.
+
+### `artifacts/release_whatsnew.md`
+
+A bulleted "What's new" list. One bullet per merged PR that ships user-facing or process-facing change. **Drop housekeeping/nit PRs that don't move gameplay, generation pipeline, or release process.** Format each bullet:
+
+```
+- **#NN — Bold headline (4–8 words)** — One or two sentences expanding into concrete impact. Cite spec/section if applicable.
+```
+
+Order by impact, not chronology. If 6+ bullets remain after dropping nits, group into thematic sub-sections (`### Gameplay`, `### Pipeline`, `### Release process`).
+
+## Constraints
+
+- **No fabrication.** Every claim must trace to a PR body, a spec diff, the postmortem, or the manifest. If you can't trace it, don't claim it.
+- **No reference-source identifiers.** Standard sanitization rules apply (no proper nouns from the source corpus, no source-code identifiers). The downstream sanitization gate will catch leaks; emit clean.
+- **No invented stats.** Use numbers from `manifest.json` only. Do not invent test counts, LoC, or token totals.
+- **No prose dump from postmortem.** Postmortem is an internal artifact — quote sparingly, paraphrase to user-facing impact. If a PostMortem "What hurt" item is process-relevant for users (e.g. "fixture authoring scope conflict was fixed"), surface it as a single line; otherwise drop.
+- **No CHANGELOG-style auto-listing.** Walk the PR titles and rewrite each into impact prose. Do not just paste merge commit messages.
+- **Emit ONLY the two files.** Do not modify specs, code, knowledge, agent prompts, or anywhere outside `artifacts/`.
+
+## Style examples
+
+**Bad:** "Worldsmith 2026.03 leverages cutting-edge multi-agent generation to deliver groundbreaking gameplay enhancements."
+
+**Good:** "This release introduces purpose-built demo levels — a small abstraction (`spec/15`) that lets each gameplay behavior have its own minimal stage. The PR-preview GIF now records on `local_chase_obstacle`, where the enemy navigates around a wall to engage the player."
+
+**Bad bullet:** "- **#15 — release: swap PR-preview demo to local_chase_obstacle scenario** — This PR swaps the demo."
+
+**Good bullet:** "- **#15 — Demo records on the obstacle scenario** — PR-preview and release demo GIFs now use `tests/level/local_chase_obstacle.yaml`, demonstrating the new level generator (`spec/15`) end-to-end. The first 4 seconds of the GIF visibly show the enemy navigating around the wall."
+
+## Failure modes
+
+- If git log between tags is empty: write a short hero saying "Patch release: <list of fixes>" and an empty whatsnew. Don't fabricate.
+- If `gh pr view` fails on a PR: include the PR number with `[title unavailable — see commit log]` rather than skipping silently.
+- If `artifacts/postmortem.md` is absent: skip its inputs; rely on PR bodies + spec diff alone. Don't fail the run.

--- a/tooling/compose_release_notes.py
+++ b/tooling/compose_release_notes.py
@@ -181,6 +181,18 @@ def render(template: str, version: str, replacements: Dict[str, str]) -> str:
     return rendered
 
 
+def load_optional_markdown(path: Optional[Path], fallback: str) -> str:
+    """Read an LLM-authored markdown fragment, falling back to `fallback` if
+    the file is absent or empty. Returning a non-empty string keeps the
+    template's section visible even when the upstream LLM phase failed —
+    the maintainer just sees the fallback and edits the draft release.
+    """
+    if path is None or not path.exists():
+        return fallback
+    text = path.read_text(encoding="utf-8").strip()
+    return text or fallback
+
+
 def run_sanitizer(target: Path) -> int:
     result = subprocess.run(
         [sys.executable, str(SANITIZER), str(target)],
@@ -202,6 +214,27 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--usage-jsonl", type=Path, default=None)
     parser.add_argument("--postmortem", type=Path, default=None)
     parser.add_argument("--manifest", type=Path, default=None)
+    parser.add_argument(
+        "--prev-version",
+        default=None,
+        help="Previous release tag, e.g. 2026.02. Substituted into {{PREV_VERSION}}. "
+             "If absent, the placeholder is left as a literal string.",
+    )
+    parser.add_argument(
+        "--release-hero",
+        type=Path,
+        default=None,
+        help="Path to artifacts/release_hero.md (LLM-authored hero pitch). If absent, "
+             "{{HERO_PITCH}} falls back to a short generic line.",
+    )
+    parser.add_argument(
+        "--release-whatsnew",
+        type=Path,
+        default=None,
+        help="Path to artifacts/release_whatsnew.md (LLM-authored what's-new bullets). "
+             "If absent, {{WHATSNEW_PROSE}} falls back to a generic note pointing at "
+             "the git log.",
+    )
     parser.add_argument(
         "--assets-dir",
         type=Path,
@@ -228,6 +261,23 @@ def main() -> int:
     usage = load_usage(args.usage_jsonl)
     manifest = load_manifest(args.manifest)
 
+    hero_pitch = load_optional_markdown(
+        args.release_hero,
+        fallback=(
+            "_(Release Editor agent did not produce a hero pitch — write one "
+            "in this draft before publishing.)_"
+        ),
+    )
+    whatsnew_prose = load_optional_markdown(
+        args.release_whatsnew,
+        fallback=(
+            "_(Release Editor agent did not produce a what's-new list — see the "
+            "merge commits in `git log` for the raw set of PRs since the previous "
+            "tag and write them up in this draft before publishing.)_"
+        ),
+    )
+    prev_version = args.prev_version or "_(previous tag)_"
+
     replacements = {
         "GENERATED_AT": manifest["generated_at"],
         "MODULE_COUNT": manifest["module_count"],
@@ -237,6 +287,9 @@ def main() -> int:
         "ASSET_TABLE": render_asset_table(args.assets_dir, args.version),
         "TOKENS_TABLE": render_tokens_table(usage),
         "POSTMORTEM_SUMMARY": load_postmortem(args.postmortem),
+        "HERO_PITCH": hero_pitch,
+        "WHATSNEW_PROSE": whatsnew_prose,
+        "PREV_VERSION": prev_version,
     }
 
     rendered = render(template, args.version, replacements)

--- a/tooling/orchestrator_run.py
+++ b/tooling/orchestrator_run.py
@@ -45,7 +45,7 @@ AGENTS_DIR = REPO_ROOT / "tooling" / "agents"
 DEFAULT_USAGE = REPO_ROOT / "artifacts" / "usage.jsonl"
 GENERATED_SRC_DIR = REPO_ROOT / "generated" / "game" / "src"
 
-PHASES = ["extractor", "architect", "coder", "reconciler", "postmortem"]
+PHASES = ["extractor", "architect", "coder", "reconciler", "postmortem", "release_editor"]
 
 # Tools each phase is permitted to invoke. Conservative defaults — broaden
 # only when the phase legitimately needs more.
@@ -55,6 +55,7 @@ PHASE_TOOLS: Dict[str, List[str]] = {
     "coder": ["Read", "Write", "Edit", "Bash", "Grep", "Glob"],
     "reconciler": ["Read", "Edit", "Bash", "Grep", "Glob"],
     "postmortem": ["Read", "Write", "Edit", "Bash", "Grep", "Glob"],
+    "release_editor": ["Read", "Write", "Bash", "Grep", "Glob"],
 }
 
 
@@ -107,6 +108,7 @@ PHASE_DEFAULT_MODEL = {
     "coder": "sonnet",
     "reconciler": "claude-opus-4-7[1m]",
     "postmortem": "claude-opus-4-7[1m]",
+    "release_editor": "claude-opus-4-7[1m]",
 }
 
 


### PR DESCRIPTION
Replaces the deadpan top-of-page copy in the release notes with two LLM-authored fragments — a hero pitch and a per-PR \"what's new\" list — generated by a new \`release_editor\` phase that runs after \`postmortem\` in \`release.yml\`. Background: the previous template surfaced token-usage tables and the post-mortem text on the top half of the page, so every release required hand-editing the draft before publishing (cf. 2026.02 — author rewrote half the page). The new layout leads with the hero pitch and GIF, then \`What's new since {{PREV_VERSION}}\`, then \`Try it\`, \`Inside the build\`, \`Read it\`, \`Assets\`, \`Known limitations\`, and finally a collapsible \`<details>\` block with the generation report.

The agent reads merged PRs via \`gh pr view\` between the previous tag and HEAD, the \`specs/\` diff between tags, \`artifacts/postmortem.md\`, and \`artifacts/manifest.json\`. It writes \`artifacts/release_hero.md\` (1–3 paragraphs OR a short bulleted list — agent picks based on content) and \`artifacts/release_whatsnew.md\` (one bullet per impactful PR, with bold 4–8-word headlines and 1–2 sentences of concrete impact). Constraints in the prompt: no marketing buzzwords, no fabricated stats, no reference-source identifier leaks. The existing sanitization gate in \`compose_release_notes.py\` runs over the final rendered notes, so leaked forbidden tokens still block publishing.

If \`release_editor\` fails for any reason (Claude CLI timeout, JSON parse, sanitization, missing OAUTH token), \`compose_release_notes.py\`'s \`load_optional_markdown\` falls back to placeholder text telling the maintainer to write the section by hand. Releases publish as drafts anyway, so the worst case is a manual edit before going public — never a broken release.

Model: Opus 4.7 1M, consistent with the other editorial phases in \`orchestrator.md § Model Selection\` (Coder stays on Sonnet; everything else is Opus). Tools: Read / Write / Bash / Grep / Glob — no Edit, since the agent only writes new artifacts.

Locally verified two paths: with both \`release_hero.md\` and \`release_whatsnew.md\` present (renders the LLM prose verbatim) and with both absent (renders the placeholder fallback so the rest of the template is still usable). Both pass sanitization. \`python3 tooling/validate_specs.py\` clean.

Order: this PR can ship before the 2026.03 release cut so the new template applies on first use. If you'd rather snapshot 2026.03 on the old template, merge after the cut — also fine.