### PR TITLE
ci: snapshot regenerated source after each merge to main

### DIFF
--- a/.github/workflows/post-merge-snapshot.yml
+++ b/.github/workflows/post-merge-snapshot.yml
@@ -1,0 +1,151 @@
+name: Snapshot regenerated source after merge
+
+# Triggered on every push to main. If the push touches source-of-truth
+# paths (specs/, knowledge/, ir/, tooling/agents/), download the
+# `generated-src` artifact from the merged PR's pr.yml run and force-push
+# its contents to the long-lived `generated-snapshot` branch. The next PR's
+# regenerate-and-build job baselines from this branch.
+#
+# Verify-only merges (no source-of-truth changes) leave the snapshot
+# untouched — the previous regen-merge stays as the canonical baseline.
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: generated-snapshot
+  cancel-in-progress: false   # queue, not last-writer-wins
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2   # need HEAD^ for the regen-detection diff
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Detect whether this push contains regen
+        id: detect
+        run: |
+          set -e
+          if git diff --name-only HEAD^..HEAD \
+             | python tooling/source_of_truth_paths.py; then
+            echo "regen=true" >> "$GITHUB_OUTPUT"
+            echo "Push touches source-of-truth paths; will update snapshot."
+          else
+            echo "regen=false" >> "$GITHUB_OUTPUT"
+            echo "Verify-only push; snapshot unchanged."
+          fi
+
+      - name: Resolve source PR
+        if: steps.detect.outputs.regen == 'true'
+        id: pr
+        run: |
+          set -e
+          PR_NUM=$(gh api "/repos/${{ github.repository }}/commits/${GITHUB_SHA}/pulls" \
+                   --jq '.[0].number // empty')
+          if [ -z "$PR_NUM" ]; then
+            echo "::warning::Direct push to main (no PR found for ${GITHUB_SHA}). Snapshot not updated."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          PR_HEAD_SHA=$(gh api "/repos/${{ github.repository }}/pulls/${PR_NUM}" \
+                        --jq '.head.sha')
+          echo "number=$PR_NUM"        >> "$GITHUB_OUTPUT"
+          echo "head_sha=$PR_HEAD_SHA" >> "$GITHUB_OUTPUT"
+          echo "Source PR: #${PR_NUM} (head ${PR_HEAD_SHA})."
+
+      - name: Find pr.yml run for that PR head SHA
+        if: steps.detect.outputs.regen == 'true' && steps.pr.outputs.skip != 'true'
+        id: run
+        run: |
+          set -e
+          RUN_ID=$(gh run list --workflow pr.yml \
+                     --commit "${{ steps.pr.outputs.head_sha }}" \
+                     --status success --limit 1 \
+                     --json databaseId --jq '.[0].databaseId // empty')
+          if [ -z "$RUN_ID" ]; then
+            echo "::warning::No successful pr.yml run for PR #${{ steps.pr.outputs.number }} head ${{ steps.pr.outputs.head_sha }}. Snapshot not updated."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "id=$RUN_ID" >> "$GITHUB_OUTPUT"
+          echo "Found pr.yml run #${RUN_ID}."
+
+      - name: Download regenerated source artifact
+        if: steps.detect.outputs.regen == 'true' && steps.pr.outputs.skip != 'true' && steps.run.outputs.skip != 'true'
+        id: download
+        run: |
+          set -e
+          if ! gh run download "${{ steps.run.outputs.id }}" \
+                  --name generated-src --dir snapshot-staging; then
+            echo "::warning::generated-src artifact missing or expired for run ${{ steps.run.outputs.id }}. Snapshot not updated."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          mkdir -p snapshot-content
+          tar -xzf snapshot-staging/generated-src.tar.gz -C snapshot-content
+          ls snapshot-content/
+
+      - name: Build SNAPSHOT.json
+        if: steps.detect.outputs.regen == 'true' && steps.pr.outputs.skip != 'true' && steps.run.outputs.skip != 'true' && steps.download.outputs.skip != 'true'
+        run: |
+          set -e
+          # The PR's regen_targets.json is in the reports artifact (uploaded
+          # under name `pr-<N>-reports` by pr.yml). Failure to fetch it is
+          # non-fatal — module list defaults to [].
+          MODULES='[]'
+          if gh run download "${{ steps.run.outputs.id }}" \
+                --name "pr-${{ steps.pr.outputs.number }}-reports" \
+                --dir reports-staging; then
+            if [ -f reports-staging/regen_targets.json ]; then
+              MODULES=$(cat reports-staging/regen_targets.json)
+            fi
+          fi
+          jq -n \
+            --arg sha    "$GITHUB_SHA" \
+            --arg pr     "${{ steps.pr.outputs.number }}" \
+            --arg run_id "${{ steps.run.outputs.id }}" \
+            --arg ts     "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --argjson mods "$MODULES" \
+            '{source_sha: $sha, source_pr: ($pr | tonumber), pr_workflow_run_id: $run_id, regenerated_modules: $mods, timestamp: $ts}' \
+            > snapshot-content/SNAPSHOT.json
+          cat snapshot-content/SNAPSHOT.json
+
+      - name: Force-push to generated-snapshot branch
+        if: steps.detect.outputs.regen == 'true' && steps.pr.outputs.skip != 'true' && steps.run.outputs.skip != 'true' && steps.download.outputs.skip != 'true'
+        run: |
+          set -e
+          cd snapshot-content
+          git init -q -b generated-snapshot
+          git config user.name  "worldsmith-snapshot-bot"
+          git config user.email "noreply@github.com"
+          git add -A
+          git commit -q -m "snapshot: source ${GITHUB_SHA} (PR #${{ steps.pr.outputs.number }})"
+          git remote add origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+          git push --force origin HEAD:refs/heads/generated-snapshot
+          echo "Pushed snapshot for ${GITHUB_SHA} (PR #${{ steps.pr.outputs.number }})."
+
+      - name: Workflow summary
+        if: always()
+        run: |
+          {
+            echo "### Snapshot result"
+            echo
+            echo "- regen detected: \`${{ steps.detect.outputs.regen }}\`"
+            echo "- source PR: \`${{ steps.pr.outputs.number || 'n/a' }}\`"
+            echo "- pr.yml run: \`${{ steps.run.outputs.id || 'n/a' }}\`"
+            echo "- artifact downloaded: \`${{ steps.download.outputs.skip != 'true' && steps.detect.outputs.regen == 'true' && 'yes' || 'no' }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -53,7 +53,7 @@ jobs:
           CHANGED=$(git diff --name-only "origin/$BASE_REF...HEAD")
           echo "Changed files relative to origin/$BASE_REF:"
           echo "$CHANGED"
-          if printf '%s\n' "$CHANGED" | grep -E '^(specs/|knowledge/|ir/|tooling/agents/)' > /dev/null; then
+          if printf '%s\n' "$CHANGED" | python tooling/source_of_truth_paths.py; then
             echo "needs_regen=true" >> "$GITHUB_OUTPUT"
           else
             echo "needs_regen=false" >> "$GITHUB_OUTPUT"
@@ -138,20 +138,34 @@ jobs:
             exit 1
           fi
 
-      - name: Download last release's source archive as baseline
+      - name: Fetch baseline (generated-snapshot branch, fallback to last release)
         id: baseline
         run: |
           set -e
-          mkdir -p artifacts
-          LAST_TAG=$(gh release view --json tagName -q .tagName)
-          echo "Baseline tag: $LAST_TAG"
-          echo "last_tag=$LAST_TAG" >> "$GITHUB_OUTPUT"
-          gh release download "$LAST_TAG" -p 'worldsmith-game-*-src.zip' -D artifacts
-          unzip -q "artifacts/worldsmith-game-${LAST_TAG}-src.zip" -d artifacts/baseline-extract
-          mkdir -p generated/game
-          # Archive layout is `worldsmith-game-<TAG>/<files>` — flatten into generated/game/.
-          cp -R "artifacts/baseline-extract/worldsmith-game-${LAST_TAG}/." generated/game/
-          rm -rf artifacts/baseline-extract "artifacts/worldsmith-game-${LAST_TAG}-src.zip"
+          mkdir -p generated/game artifacts
+          if git ls-remote --exit-code origin generated-snapshot >/dev/null 2>&1; then
+            git fetch origin generated-snapshot --depth=1
+            git archive --format=tar refs/remotes/origin/generated-snapshot \
+              | tar -x -C generated/game
+            SOURCE_SHA="snapshot-branch"
+            if [ -f generated/game/SNAPSHOT.json ]; then
+              SOURCE_SHA=$(jq -r .source_sha generated/game/SNAPSHOT.json)
+              rm -f generated/game/SNAPSHOT.json
+            fi
+            echo "baseline=generated-snapshot@${SOURCE_SHA}" >> "$GITHUB_OUTPUT"
+            echo "Fetched baseline from generated-snapshot (source ${SOURCE_SHA})."
+          else
+            # First-run fallback: until the snapshot branch is created by the
+            # first regen-bearing merge under the new flow, fall back to the
+            # last published release's source zip.
+            LAST_TAG=$(gh release view --json tagName -q .tagName)
+            echo "Snapshot branch missing; falling back to release ${LAST_TAG}."
+            gh release download "$LAST_TAG" -p 'worldsmith-game-*-src.zip' -D artifacts
+            unzip -q "artifacts/worldsmith-game-${LAST_TAG}-src.zip" -d artifacts/baseline-extract
+            cp -R "artifacts/baseline-extract/worldsmith-game-${LAST_TAG}/." generated/game/
+            rm -rf artifacts/baseline-extract "artifacts/worldsmith-game-${LAST_TAG}-src.zip"
+            echo "baseline=release-${LAST_TAG}" >> "$GITHUB_OUTPUT"
+          fi
           ls generated/game/
 
       - name: Determine regeneration scope
@@ -194,6 +208,23 @@ jobs:
           set -e
           xvfb-run -a cargo build --release --manifest-path generated/game/Cargo.toml
           xvfb-run -a cargo test --release --manifest-path generated/game/Cargo.toml
+
+      - name: Package regenerated source for post-merge snapshot
+        if: steps.scope.outputs.module_count != '0'
+        run: |
+          set -e
+          mkdir -p artifacts
+          tar -czf artifacts/generated-src.tar.gz -C generated/game \
+            --exclude=target --exclude=.git .
+
+      - name: Upload regenerated source artifact
+        if: steps.scope.outputs.module_count != '0'
+        uses: actions/upload-artifact@v4
+        with:
+          name: generated-src
+          path: artifacts/generated-src.tar.gz
+          retention-days: 90
+          if-no-files-found: error
 
       - name: Record gameplay GIF
         run: |
@@ -287,16 +318,16 @@ jobs:
           REPO: ${{ github.repository }}
           MODULE_COUNT: ${{ steps.scope.outputs.module_count }}
           TARGETS: ${{ steps.scope.outputs.targets }}
-          BASELINE_TAG: ${{ steps.baseline.outputs.last_tag }}
+          BASELINE: ${{ steps.baseline.outputs.baseline }}
           GIF_URL: ${{ steps.gif-push.outputs.raw_url }}
           STATUS: ${{ job.status }}
         run: |
           set -e
           ARTIFACTS_URL="https://github.com/${REPO}/actions/runs/${RUN_ID}#artifacts"
           if [ "$MODULE_COUNT" = "0" ]; then
-            SCOPE_LINE="No module-specific targets identified by partial_regen.py (likely a manual-scope spec or pure agent-prompt edit). Skipped Coder/Reconciler/PostMortem; ran cargo build/test on baseline \`${BASELINE_TAG}\` as smoke check."
+            SCOPE_LINE="No module-specific targets identified by partial_regen.py (likely a manual-scope spec or pure agent-prompt edit). Skipped Coder/Reconciler/PostMortem; ran cargo build/test on baseline \`${BASELINE}\` as smoke check."
           else
-            SCOPE_LINE="Regenerated modules from baseline \`${BASELINE_TAG}\`: \`${TARGETS}\`"
+            SCOPE_LINE="Regenerated modules from baseline \`${BASELINE}\`: \`${TARGETS}\`"
           fi
           {
             echo "## PR Checks — \`${STATUS}\`"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,14 +113,26 @@ Workflow: `Reference → Extractor → knowledge/ → Architect → specs/ → C
 
 - **`validate`** — always runs. Validates specs/IR/knowledge integrity, checks `generated/` for manual edits, and computes whether the PR touches `specs/**`, `knowledge/**`, `ir/**`, or `tooling/agents/**` (the source-of-truth paths).
 - **`regenerate-and-build`** — runs only when (a) source-of-truth paths changed AND (b) the PR head is from this repo (fork PRs are skipped because the OAUTH secret is unavailable to forked workflows). Steps:
-  1. Download last release's `worldsmith-game-X-src.zip` as a baseline and unpack into `generated/game/`.
+  1. Fetch baseline from the long-lived `generated-snapshot` branch (force-pushed by `post-merge-snapshot.yml` after every regen-bearing merge). On first run before that branch exists, fall back to the last GitHub Release's `worldsmith-game-X-src.zip`.
   2. `tooling/partial_regen.py --json` — determine which modules need regeneration.
   3. Coder / Reconciler / PostMortem phases via `tooling/orchestrator_run.py --target-modules ...`. The harness snapshots `generated/game/src/` and reverts any file touched outside the listed modules — so Coder can't silently scope-creep.
   4. `cargo build/test --release` (under `xvfb-run` because autopilot tests need a display).
-  5. Record `release/demo.gif` via `tooling/record_autopilot.sh`.
-  6. Reconciler's edits to `specs/`, `knowledge/`, `ir/`, `tooling/agents/` and PostMortem's surgical edits to `tooling/agents/*.md` are captured as a unified diff and posted as **inline review suggestions** via `reviewdog/action-suggester` (only on lines this PR already touches; the rest of the diff is in the `agent_changes.diff` artifact).
-  7. PostMortem's narrative analysis (run summary, "what hurt", ADR drafts) is saved to `artifacts/postmortem.md` and linked from the PR comment.
-  8. The demo GIF is uploaded to a single shared `pr-assets` branch (auto-created on first run from `main`'s HEAD) as `pr-<N>-run-<run_id>-demo.gif`, then embedded inline in the PR status comment via its `raw.githubusercontent.com` URL. PR number + run id make filenames unique, so concurrent PR runs don't race. The branch is **never automatically pruned** — see Known Issues for cleanup.
+  5. Package the regenerated `generated/game/` into `generated-src.tar.gz` and upload it as a workflow artifact (90-day retention). `post-merge-snapshot.yml` consumes this after merge.
+  6. Record `release/demo.gif` via `tooling/record_autopilot.sh`.
+  7. Reconciler's edits to `specs/`, `knowledge/`, `ir/`, `tooling/agents/` and PostMortem's surgical edits to `tooling/agents/*.md` are captured as a unified diff and posted as **inline review suggestions** via `reviewdog/action-suggester` (only on lines this PR already touches; the rest of the diff is in the `agent_changes.diff` artifact).
+  8. PostMortem's narrative analysis (run summary, "what hurt", ADR drafts) is saved to `artifacts/postmortem.md` and linked from the PR comment.
+  9. The demo GIF is uploaded to a single shared `pr-assets` branch (auto-created on first run from `main`'s HEAD) as `pr-<N>-run-<run_id>-demo.gif`, then embedded inline in the PR status comment via its `raw.githubusercontent.com` URL. PR number + run id make filenames unique, so concurrent PR runs don't race. The branch is **never automatically pruned** — see Known Issues for cleanup.
+
+### Post-merge snapshot (`generated-snapshot` branch)
+
+`.github/workflows/post-merge-snapshot.yml` triggers on every push to `main`. Flow:
+
+1. Diff `HEAD^..HEAD` against source-of-truth prefixes via `tooling/source_of_truth_paths.py`. Verify-only merges (no spec/knowledge/IR/agent changes) exit early — the previous regen-merge stays as the canonical baseline.
+2. Resolve the source PR via `gh api commits/<sha>/pulls`. Direct pushes to `main` (no PR) are skipped with a warning.
+3. Find the latest successful `pr.yml` run for the PR's head SHA, download the `generated-src` artifact.
+4. Force-push the artifact contents (loose `Cargo.toml`, `Cargo.lock`, `src/`, `assets/`, …) plus a `SNAPSHOT.json` (`source_sha`, `source_pr`, `pr_workflow_run_id`, `regenerated_modules`, `timestamp`) to the `generated-snapshot` branch as an orphan commit — no history accumulated. Concurrency is `group: generated-snapshot, cancel-in-progress: false` so two near-simultaneous merges land in commit order.
+
+The next PR's `regenerate-and-build` step 1 fetches from this branch, so each PR baselines from the most recent regen-bearing merge instead of from the last manual release. `tooling/source_of_truth_paths.py` is the single source of truth used by both `pr.yml` impact-analysis and this workflow's regen detection — keep them in sync via the helper, never duplicate the prefix list.
 
 ### Branch protection (one-time setup)
 
@@ -171,3 +183,4 @@ Local helper: the project-level skill `/create-agent-task` (`.claude/skills/crea
 
 - Top-down view, not raycasting
 - The shared `pr-assets` branch grows by one file per PR run and is never pruned automatically. Periodic cleanup is needed — either a cron workflow that drops files older than N days, or a `pull_request: types: [closed]` workflow that deletes `pr-<N>-*.gif` for the closed PR. Not implemented yet.
+- The `generated-snapshot` branch is force-pushed and orphan-committed each time, so historical snapshots are not retained — only the latest regen-merge baseline lives there. If you need a previous baseline, fall back to the corresponding GitHub Release's `worldsmith-game-X-src.zip`. If a PR sits open for more than 90 days, its `generated-src` artifact expires and the post-merge snapshot can no longer pick it up — `post-merge-snapshot.yml` warns and skips, leaving the previous snapshot in place; refresh manually via `release.yml` if needed.

--- a/tooling/source_of_truth_paths.py
+++ b/tooling/source_of_truth_paths.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""
+Source-of-truth path detection for CI gating.
+
+Both `.github/workflows/pr.yml` (impact analysis) and
+`.github/workflows/post-merge-snapshot.yml` (regen detection on main) use
+this to decide whether a changeset touches the agent-authored sources
+that drive regeneration. Keeping it in one place prevents the two
+workflows from drifting on the definition of "this PR/merge contains
+regen".
+
+CLI: read newline-separated paths from stdin, exit 0 if any path matches
+a source-of-truth prefix, exit 1 otherwise.
+
+    git diff --name-only HEAD^..HEAD | python tooling/source_of_truth_paths.py
+"""
+
+from __future__ import annotations
+
+import sys
+
+
+SOURCE_OF_TRUTH_PREFIXES: tuple[str, ...] = (
+    "specs/",
+    "knowledge/",
+    "ir/",
+    "tooling/agents/",
+)
+
+
+def is_source_of_truth(path: str) -> bool:
+    return any(path.startswith(prefix) for prefix in SOURCE_OF_TRUTH_PREFIXES)
+
+
+def main() -> int:
+    for line in sys.stdin:
+        if is_source_of_truth(line.strip()):
+            return 0
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Each PR's `regenerate-and-build` job currently baselines `generated/game/` from the last GitHub Release's source zip. Releases are manual (`workflow_dispatch`), so between releases every PR regenerates from a stale baseline — independent PRs cannot see each other's regen output, and serial work on the same module redoes effort that already merged.

This change replaces that baseline source with a long-lived `generated-snapshot` branch updated on every regen-bearing merge to `main`. Verify-only merges (no changes under `specs/`, `knowledge/`, `ir/`, `tooling/agents/`) leave the snapshot untouched, so the next PR baselines from the most recent regen-merge — exactly matching the "or the previous one if the latest merge had no regen" rule.

Mechanism:

- New `tooling/source_of_truth_paths.py` helper centralises the four prefixes. Both `pr.yml` impact-analysis and the new post-merge workflow call it via stdin, so the definition of "this change contains regen" cannot drift between the two places.
- `pr.yml` now (1) tries the snapshot branch first via `git fetch` + `git archive`, falling back to `gh release download` only when the branch doesn't yet exist, and (2) packages the regenerated `generated/game/` into a `generated-src.tar.gz` workflow artifact (90-day retention) after `cargo build/test` succeeds.
- `.github/workflows/post-merge-snapshot.yml` (new) fires on `push: main`. It diffs `HEAD^..HEAD` through the helper, resolves the source PR via `gh api commits/<sha>/pulls`, downloads `generated-src` from that PR's `pr.yml` run, and orphan-force-pushes the contents plus a `SNAPSHOT.json` (`source_sha`, `source_pr`, `pr_workflow_run_id`, `regenerated_modules`, `timestamp`) to the `generated-snapshot` branch. `concurrency: cancel-in-progress: false` queues near-simultaneous merges so each `SNAPSHOT.json.source_sha` matches the actual `main` HEAD at push time.

Edge cases handled by skip-and-warn (not failure): direct push to `main` without a PR; no successful `pr.yml` run for the head SHA; expired artifact (>90 days). In all three cases the prior snapshot stays valid as a baseline (one merge older); manual `release.yml` refreshes it if needed. CLAUDE.md updated for the new flow plus two Known Issues notes.

End-to-end verification (intended once landed): a trivial spec-PR creates the snapshot branch with a correct `SNAPSHOT.json`; a README-only PR leaves it unchanged; a follow-up spec-PR's baseline-fetch step shows `generated-snapshot@<sha>` in the PR comment, not the release fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)