### PR TITLE
orchestrator: inline frozen context at the top of every agent prompt

### DIFF
--- a/tooling/orchestrator_run.py
+++ b/tooling/orchestrator_run.py
@@ -45,6 +45,38 @@ AGENTS_DIR = REPO_ROOT / "tooling" / "agents"
 DEFAULT_USAGE = REPO_ROOT / "artifacts" / "usage.jsonl"
 GENERATED_SRC_DIR = REPO_ROOT / "generated" / "game" / "src"
 
+# Read-only inputs that are stable across all phases of a regen pass. Inlined
+# verbatim at the top of every agent prompt so the Anthropic prompt-cache
+# matches their prefix across consecutive `claude -p` calls — agents can still
+# Read these via tool call, but the inlined copy is what the cache keys off.
+#
+# STRICT ALLOWLIST: only files that the regen pass DOES NOT mutate may appear
+# here. specs/25_game_tuning.md (Reconciler writes to it) and the per-module
+# ir/contracts/<module>.yaml shards (Architect writes to them) are deliberately
+# excluded. The assertion below guards against accidental additions.
+FROZEN_CONTEXT_FILES: List[str] = [
+    "specs/00_project_goal.md",
+    "specs/10_system_model.md",
+    "specs/80_generation_rules.md",
+    "ir/game_ir.yaml",
+    "ir/module_plan.yaml",
+    "ir/contracts/_shared.yaml",
+]
+
+_FROZEN_FORBIDDEN_PREFIXES = (
+    "specs/25_game_tuning.md",  # Reconciler writes
+    "ir/contracts/",            # per-module shards (only _shared.yaml allowed)
+)
+for _path in FROZEN_CONTEXT_FILES:
+    for _bad in _FROZEN_FORBIDDEN_PREFIXES:
+        if _path.startswith(_bad) and _path != "ir/contracts/_shared.yaml":
+            raise AssertionError(
+                f"FROZEN_CONTEXT_FILES contains mutable file `{_path}`. "
+                f"Only stable, regen-pass-immutable files belong here — agents "
+                f"that write to a file must NOT see it inlined as frozen "
+                f"context (the cache key would invalidate every time)."
+            )
+
 PHASES = ["extractor", "architect", "coder", "reconciler", "postmortem", "release_editor"]
 
 # Tools each phase is permitted to invoke. Conservative defaults — broaden
@@ -73,6 +105,34 @@ class PhaseUsage:
     notes: List[str] = field(default_factory=list)
 
 
+def build_frozen_context() -> str:
+    """Inline every file in FROZEN_CONTEXT_FILES verbatim. Missing files are
+    skipped with a sentinel line so the prompt is still well-formed (e.g. on
+    a checkout that predates the file)."""
+    sections: List[str] = []
+    for rel_path in FROZEN_CONTEXT_FILES:
+        path = REPO_ROOT / rel_path
+        sections.append(f"### {rel_path}\n")
+        if path.exists():
+            try:
+                content = path.read_text(encoding="utf-8")
+            except OSError as exc:
+                sections.append(f"_(read error: {exc})_\n")
+                continue
+            sections.append(f"```\n{content}\n```\n")
+        else:
+            sections.append("_(file not present in this checkout)_\n")
+    body = "\n".join(sections)
+    header = (
+        "## Frozen context\n\n"
+        "The files below are read-only inputs for this regen pass. They are "
+        "inlined here so the prompt cache hits across consecutive agent "
+        "invocations. You may still re-read them via the Read tool; the "
+        "inlined copy is for cache stability, not for restricting your access."
+    )
+    return f"{header}\n\n{body}"
+
+
 def build_prompt(phase: str, mode: str, scope: Optional[str]) -> str:
     role_prompt_path = AGENTS_DIR / f"{phase}.md"
     if not role_prompt_path.exists():
@@ -96,7 +156,10 @@ def build_prompt(phase: str, mode: str, scope: Optional[str]) -> str:
         "`artifacts/blocker.md` and exit. When you are done, exit normally."
     )
 
-    return "\n\n".join([framing, scope_block, "---", role_prompt])
+    # Order matters for prompt-cache prefix matching: most-stable content first.
+    # frozen_context is identical across every phase + scope combination, so it
+    # forms the largest cacheable prefix.
+    return "\n\n".join([build_frozen_context(), framing, scope_block, "---", role_prompt])
 
 
 # Pin per-phase. CLI default is Sonnet 4.6 (200K) which blew up on issue #6.


### PR DESCRIPTION
Stacked on top of #20 (`ir/shard-module-contracts`). Merge #20 first; this PR will retarget to `main` automatically once that lands.

Every regen-pass agent (Architect / Coder / Reconciler / PostMortem) currently re-reads the same six stable inputs via the Read tool on every invocation: `specs/00_project_goal.md`, `specs/10_system_model.md`, `specs/80_generation_rules.md`, `ir/game_ir.yaml`, `ir/module_plan.yaml`, and `ir/contracts/_shared.yaml`. Each Read pays full input-token cost because the prompt-cache prefix never sees those bytes.

Inline the six files verbatim at the top of `build_prompt()`. The prompt-cache prefix now stably matches across consecutive `claude -p` calls, so every invocation after the first serves the ~11K frozen block from cache instead of recreating it.

Strict allowlist enforced at module load (`AssertionError` if violated):
- `specs/25_game_tuning.md` is forbidden — Reconciler writes to it during a regen pass.
- `ir/contracts/<module>.yaml` shards are forbidden — Architect writes to them.
- Only `ir/contracts/_shared.yaml` is whitelisted from the `ir/contracts/` tree.

Admitting a mutable file would invalidate the cache key on every regen pass and silently delete the saving — the assertion catches that at script load.

Tier 1 idea #3 of the spec/ir growth plan. Expected best case: 30-50% off Coder phase input tokens after the first invocation. PR 3 (move spec/25 reconcile-residue out to a log) follows.

Verification:
- Smoke test: `build_prompt('coder', 'release', 'Regenerate ONLY modules: weapon_system')` returns a 44K-character prompt that begins with `## Frozen context`, includes `shared_types:` from `_shared.yaml`, and ends with the role prompt + scope override.
- `python3 tooling/validate_specs.py --verbose` → all checks pass.