### PR TITLE
specs/reconciler: split future provenance writes between specs/25 and work/

### DIFF
--- a/specs/25_game_tuning.md
+++ b/specs/25_game_tuning.md
@@ -4,6 +4,14 @@
 
 This spec captures all gameplay balance constants, visual parameters, and level layout values. Values are derived from knowledge extraction (see `knowledge/combat_balance.md`, `knowledge/enemy_types.md`, `knowledge/player_movement.md`), not invented.
 
+## Reconcile-pass row format (for new entries)
+
+When the Reconciler captures a new constant during a regen pass, the canonical row in this file holds **only** the value plus a ≤1-sentence rationale, and ends with `(see reconcile_log#<anchor>)`. The full audit trail — where the constant was inlined in code, what alternatives were considered, prior incarnations, the run that captured it — lives in `work/reconcile_history.md` (gitignored, accumulated locally and surfaced through PostMortem's run journal).
+
+This split exists so this file stays *stable across a regen pass*: downstream phases (Coder, PostMortem, release_editor) re-read it on every Coder invocation, and provenance prose written by an earlier phase invalidates the prompt cache for everyone after it. See `tooling/agents/reconciler.md § Step 1` for the writer-side rule and `tooling/orchestrator_run.py § FROZEN_CONTEXT_FILES` for the cache-stability rationale.
+
+Existing rows below this point predate the convention and are kept verbatim — they are stable and cached. The split applies to new captures from this point forward.
+
 ## Player
 
 | Constant | Value | Source |

--- a/tooling/agents/reconciler.md
+++ b/tooling/agents/reconciler.md
@@ -53,7 +53,14 @@ Read each generated module. For every numeric constant, struct field default, or
 - Is it derived from a knowledge file?
 - Or was it invented during generation?
 
-If invented → add to `specs/25_game_tuning.md` with source marked as "generation default — needs extraction".
+If invented → split the entry into TWO writes:
+
+1. **Canonical row in `specs/25_game_tuning.md`**: `Constant | Value | Brief rationale (≤1 sentence). (see reconcile_log#<anchor>)`. Keep this terse — it is the row downstream Coder/PostMortem phases will re-read every regen, and it must stay stable across the pass.
+2. **Audit-trail entry in `work/reconcile_history.md`** (gitignored): the full provenance — where the constant was inlined in code, what alternatives were considered, the run that captured it, any "captured during reconcile pass" / "was inlined as X in <file>.rs" notes, and the cross-references to other constants. Anchor each entry with `## <CONSTANT_NAME>` so the spec row's `(see reconcile_log#<anchor>)` resolves.
+
+Why split? The canonical row is read N times per regen (once per Coder invocation). The audit trail is read 0 times by agents — it exists for human review across runs. Inlining the audit trail invalidates the prompt cache for every downstream phase whenever a new constant is captured. See `tooling/orchestrator_run.py` § FROZEN_CONTEXT_FILES for why cache stability matters.
+
+`work/` is gitignored, so the audit log accumulates locally and is included in the run journal artifact via PostMortem; do not try to commit it.
 
 ### Step 2: Check spec coverage
 
@@ -96,7 +103,7 @@ Produce a summary:
 - [warning]: [drift / pre-existing noise / fixed]
 
 ### Values captured
-- [constant]: [value] → added to specs/25_game_tuning.md
+- [constant]: [value] → canonical row added to specs/25_game_tuning.md; provenance appended to work/reconcile_history.md#<anchor>
 
 ### Specs updated
 - [spec file]: marked [feature] as deferred
@@ -112,7 +119,8 @@ The report must also be appended to `work/pipeline_run_<tag>.md` (the run journa
 
 ## Output
 
-- Updated `specs/25_game_tuning.md` (new constants)
+- Updated `specs/25_game_tuning.md` (new constants — canonical row only: value + ≤1-sentence rationale + `(see reconcile_log#<anchor>)`)
+- Appended `work/reconcile_history.md` (gitignored audit trail — full provenance for each new constant)
 - Updated spec files (implementation status sections)
 - Reconcile report (printed to conversation)
 


### PR DESCRIPTION
Stacked on #21 (`orchestrator/inline-frozen-context`), which is itself stacked on #20 (`ir/shard-module-contracts`). Merge #20 → #21 → this PR.

Reconciler currently inlines new constants AND their full provenance prose into `specs/25_game_tuning.md` mid-regen. Every inline write invalidates the prompt-cache prefix that downstream phases (Coder, PostMortem, release_editor) reuse for the rest of the pass.

Future captures split into two writes:

1. **Canonical row in `specs/25`** — value + ≤1-sentence rationale + `(see reconcile_log#<anchor>)`. Stable across the pass; the prompt cache survives.
2. **Audit trail in `work/reconcile_history.md`** (gitignored) — full provenance, code-site references, alternatives considered, "captured during reconcile pass" / "was inlined as X in <file>.rs" notes. Read by humans across runs; not by agents during a regen pass.

Existing 44 captured rows in `specs/25` stay verbatim — they're stable and cached, and several rely on their inline prose for real signal (e.g. L126's `| GAME_OVER_BORDER_WIN_COLOR | inlined at renderer.rs:261 (if-arm) | …` uses the "inlined at …" string as the *value* column to note a constant that hasn't been promoted to a named `pub const` yet). Retroactively scrubbing them would delete that signal. The convention applies to new captures from this point forward.

Trade-off vs. the original Tier 1 #2 plan: the one-time ~30% line-shrink of `specs/25` is forfeited. The plan itself flagged "Real saving is downstream cache survival, not the line trim" — that win is delivered. Future Reconciler runs stop mutating `specs/25` mid-pass, so Coder/PostMortem/release_editor keep their prompt cache.

Verification:
- `python3 tooling/validate_specs.py --verbose` → all checks pass.
- `python3 tooling/run_evals.py` → cargo build + 96 tests pass.