### PR TITLE
specs/20: scope GAME_OVER_HOLD_SEC rule to interactive mode

### DIFF
--- a/specs/20_gameplay_model.md
+++ b/specs/20_gameplay_model.md
@@ -124,7 +124,7 @@ Two pickup types exist in the level: health and ammo. Walking the player onto a 
 
 ### Game Over Flow
 
-When the player either reaches the exit (`won = true`) or dies (`alive = false`), the engine MUST continue to render for at least `GAME_OVER_HOLD_SEC` seconds before exiting the main loop. The game-over colored border (green for win, red for lose; spec/50 § Render Order Update) and the HUD remain visible during the hold. The implementation MUST NOT exit on the same tick that the win/lose state is detected — that produces a zero-frame render of the game-over overlay and the player never sees the outcome.
+**Interactive mode (no `--autopilot` flag).** When the player either reaches the exit (`won = true`) or dies (`alive = false`), the engine MUST continue to render for at least `GAME_OVER_HOLD_SEC` seconds before exiting the main loop. The game-over colored border (green for win, red for lose; spec/50 § Render Order Update) and the HUD remain visible during the hold. The implementation MUST NOT exit on the same tick that the win/lose state is detected — that produces a zero-frame render of the game-over overlay and the player never sees the outcome.
 
 Concretely, this requires the loop-exit *decision* and the loop-exit *action* to be separated:
 - The decision (game over reached) flips a "game_over since" timestamp in the game state.
@@ -134,6 +134,8 @@ Concretely, this requires the loop-exit *decision* and the loop-exit *action* to
 `GAME_OVER_HOLD_SEC` is defined in [`25_game_tuning.md`](25_game_tuning.md#visual). After the hold elapses the loop may exit immediately or wait for player input — the latter is **deferred**.
 
 (Rationale: an earlier generated game flipped `running = false` on the same tick that the win/lose flag was set, then the `while window.is_open() && game.running` loop in `main.rs` exited before the next `draw()` call. The colored border rendered for zero frames. The fix is the decision/action separation described above.)
+
+**Autopilot mode (`--autopilot <path>`).** The bot's `BotProgress::AllObjectivesComplete` signal terminates the loop on the next iteration, per `ir/contracts/_shared.yaml § main_cli`. The colored game-over border therefore renders for one frame in autopilot recordings — short enough that no human-perceptible hold occurs, which is intentional: specs/35 § Tooling Contract caps demo length below the 2-second hold duration so demo GIFs stay under the recording-time budget. The decision/action separation above still applies inside `game_loop::update`, but `main.rs`'s autopilot branch flips `running = false` on `AllObjectivesComplete` regardless of `game_over_at`, overriding the hold for this mode only.
 
 ## Implementation Status
 


### PR DESCRIPTION
Resolves the lone drift item flagged by Reconciler in PR #20's release regen — autopilot mode contradicts `specs/20 § Game Over Flow`'s unconditional 2.0-second hold rule.

`ir/contracts/_shared.yaml § main_cli` (lines 138 / autopilot branch) pins `BotProgress::AllObjectivesComplete => game.running = false` — terminates the loop on the next iteration, regardless of `game_over_at`. The colored win/lose border therefore renders for exactly one frame in autopilot recordings.

This is intentional contract pinning, not a Coder mistake: `specs/35 § Tooling Contract` caps demo length below the 2-second hold duration, so adding a 120-frame pad to every recording would blow the budget. The fix is to scope the spec/20 rule to interactive mode and document the autopilot exception.

Spec text now reads:

- **Interactive mode** — original "at least `GAME_OVER_HOLD_SEC` seconds" rule, unchanged.
- **Autopilot mode** — `BotProgress::AllObjectivesComplete` overrides the hold; one-frame border render is intentional per the demo-length budget.

The decision/action separation inside `game_loop::update` is unchanged — both modes share that mechanism. Only `main.rs`'s autopilot branch overrides the hold.

Refs: PR #20 release regen `reconciler_report.md § Drift found item 1`; `postmortem.md § Decision N` ADR draft.

### Companion ADR draft (not implemented here)

PostMortem also drafted **Decision N+1** (separate concern): extend `tooling/orchestrator_run.py` or the workflow to parse `### Drift found` sections from `reconciler_report.md` and surface them in the PR comment automatically. Without that, drift items only reach reviewers via workflow-log artifacts — easy to miss. Not in this PR's scope; track separately.

Verification:
- `python3 tooling/validate_specs.py --verbose` → all checks pass.
- `python3 tooling/run_evals.py` → cargo build + tests pass.