### PR TITLE
tooling: bump default max-turns from 80 to 160

### DIFF
--- a/tooling/orchestrator_run.py
+++ b/tooling/orchestrator_run.py
@@ -19,7 +19,7 @@ Inputs:
 - --scope            optional free-text scope (forwarded into the prompt)
 - --usage-jsonl      output path for the usage record (default: artifacts/usage.jsonl)
 - --transcript       optional path to also save the raw stream-json transcript
-- --max-turns        cap on agent turns (default: 80)
+- --max-turns        cap on agent turns (default: 160)
 - --model            override the Claude model id (default: inherits from CLI/env)
 
 Exit codes:
@@ -328,7 +328,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--scope", default=None)
     parser.add_argument("--usage-jsonl", type=Path, default=DEFAULT_USAGE)
     parser.add_argument("--transcript", type=Path, default=None)
-    parser.add_argument("--max-turns", type=int, default=80)
+    parser.add_argument("--max-turns", type=int, default=160)
     parser.add_argument("--model", default=None)
     parser.add_argument(
         "--target-modules",


### PR DESCRIPTION
Issue #26's Extractor phase hit the 80-turn cap mid-flight (`terminal_reason: max_turns`, `num_turns: 81`, $7.14 spent at ~50% completion). Pre-failure metrics looked healthy — 9.2M cache reads, medium output volume, no permission denials — so the agent was actively producing, just running out of rope on a reference-anchored extraction task.

Doubling the default keeps the cap as a runaway safeguard while giving Extractor + Architect room to finish a reference-anchored task in one go. Phases that finish faster pay nothing extra — `max-turns` is a ceiling, not a target.

Source-of-truth paths untouched, so `regenerate-and-build` will be skipped (only `validate` runs).