### PR TITLE
Harden knowledge sanitization gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,12 @@ This project's whole proposition is "specs distilled from a real reference, rege
 
 2. **Only the Extractor writes to `knowledge/`, and only when `reference/` is loaded.** Architect, Orchestrator, Reconciler, and PostMortem must never add or modify knowledge files. If a spec value has no knowledge backing, mark its Source as `Generation default — no knowledge backing` in `specs/25_game_tuning.md` and add a parking-lot item to the run journal — never invent a knowledge citation. See `tooling/agents/architect.md` § Citation discipline.
 
-`tooling/validate_specs.py` enforces this mechanically: a session that modifies `knowledge/` while `reference/` is empty fails validation with a loud banner. Trust the gate; do not work around it. If the gate fires unexpectedly, the right responses are (a) revert the knowledge edit, (b) load the relevant reference and re-run Extractor properly, or (c) demote the value to a `Generation default` in spec/25.
+`tooling/validate_specs.py` enforces this mechanically. Two hard rules, no warning paths:
+
+- A session that modifies `knowledge/` while `reference/` is empty fails validation with a loud banner.
+- Any forbidden source-identifier token (proper nouns, source-code identifiers, release-year sentinels) in any `knowledge/*.md` fails validation, regardless of git status. The pattern table lives in `tooling/check_sanitization.py`. Pre-existing leaks in committed files must be cleaned up in the same PR that next touches the affected file.
+
+Trust the gate; do not work around it. If the gate fires unexpectedly, the right responses are (a) revert the knowledge edit, (b) load the relevant reference and re-run Extractor properly, (c) demote the value to a `Generation default` in spec/25, or (d) for sanitization leaks, paraphrase the offending text without changing numerics.
 
 ## Auto-Documentation Rules
 

--- a/knowledge/combat_balance.md
+++ b/knowledge/combat_balance.md
@@ -14,7 +14,7 @@ The reference game uses a deterministic pseudo-random number generator (a fixed 
   - Pistol / chaingun: `5 * (rnd%3 + 1)` = 5, 10, or 15 per shot (mean ~10)
   - Shotgun: 7 pellets, each using the pistol formula, total 35-105 (mean ~70)
   - Super shotgun: 20 pellets, each `5 * (rnd%3 + 1)`, total 100-300 (mean ~200)
-  - Fist: `(rnd%10 + 1) * 2` = 2-20 (mean ~11); berserk multiplies by 10 = 20-200
+  - Fist: `(rnd%10 + 1) * 2` = 2-20 (mean ~11); melee strength powerup multiplies by 10 = 20-200
   - Enemy hitscan (basic grunt): `((rnd%5) + 1) * 3` = 3-15 per shot (mean ~9)
   - Shotgun grunt: 3 pellets at `((rnd%5) + 1) * 3` each = 9-45 total
 - **Feel**: The discrete damage tiers (5/10/15 for pistol) create a subtle "lucky hit" / "weak hit" dynamic. Most shots cluster around the mean but occasionally spike or dip
@@ -121,11 +121,11 @@ The reference game uses a deterministic pseudo-random number generator (a fixed 
   - Starting ammo: 50 bullets (clip type)
   - Clip pickup: 10 bullets (half = 5 from dropped clips)
   - Box of bullets: 50
-  - Max ammo (bullets): 200 (400 with backpack)
+  - Max ammo (bullets): 200 (400 with ammo capacity expander)
   - Pistol: 1 bullet per shot
   - Chaingun: 1 bullet per shot (but fires 2 per cycle)
   - Shotgun: 1 shell per shot
-  - Max ammo (shells): 50 (100 with backpack)
+  - Max ammo (shells): 50 (100 with ammo capacity expander)
 - **Feel**: Starting with 50 bullets means ~25 basic troopers worth of ammo at average damage, or only ~8 ranged-melee hybrids. This creates early scarcity pressure that drives exploration and weapon acquisition
 
 ### Damage Randomization System
@@ -167,7 +167,7 @@ The reference game uses a deterministic pseudo-random number generator (a fixed 
 | Shotgun damage | 35-105 (7 pellets) | Mean ~70 |
 | Shotgun fire cycle | 44 ticks (~1.26s) | ~0.80 shots/sec |
 | Chaingun fire cycle | 8 ticks (~0.23s) | 2 shots per cycle |
-| Fist damage | 2-20 | Berserk: 20-200 |
+| Fist damage | 2-20 | Melee strength powerup: 20-200 |
 | Hitscan range | 2048 world units | Effectively infinite indoors |
 | Melee range | 64 world units | Very close |
 | Auto-aim range | 1024 world units | For bullet slope |
@@ -183,7 +183,7 @@ The reference game uses a deterministic pseudo-random number generator (a fixed 
 | Blue armor absorption | 50% | Type 2 |
 | Starting ammo (bullets) | 50 | ~25 basic trooper kills |
 | Clip pickup | 10 bullets | Half from drops |
-| Max bullets | 200 | 400 with backpack |
+| Max bullets | 200 | 400 with ammo capacity expander |
 | Enemy spread (grunt) | +/- ~22 deg max | 4x wider than player |
 | Pain chance (basic trooper) | 200/256 (~78%) | High stagger rate |
 | Pain chance (ranged-melee hybrid) | 200/256 (~78%) | High stagger rate |

--- a/knowledge/enemy_types.md
+++ b/knowledge/enemy_types.md
@@ -68,7 +68,7 @@ Enemies in the classic reference FPS share a common AI framework built around a 
 - **Behavior**: A probability-based check that determines whether an enemy should fire. Enemies at close range almost always fire, while distant enemies fire less often. This creates natural attack patterns without explicit timers.
 - **Rules**:
   - Requires line of sight to the target (via the line-of-sight check)
-  - If the target just hit the enemy (MF_JUSTHIT flag), always fire (fight back immediately)
+  - If the target just hit the enemy (the recently-hit flag, set when the monster takes damage and cleared on the next AI tick), always fire (fight back immediately)
   - If reaction time is non-zero, never fire
   - Base distance is the approximate distance to the target minus 64 units
   - For enemies with no melee attack (like the basic trooper), subtract an additional 128 units from the distance, making them fire more aggressively at range
@@ -121,7 +121,7 @@ Enemies in the classic reference FPS share a common AI framework built around a 
 - **Rules**:
   - On each damage event, a random number 0-255 is compared to the enemy's pain chance
   - If the random number is less than the pain chance, the enemy enters its pain state
-  - The pain state sets MF_JUSTHIT, causing the enemy to retaliate immediately on recovery
+  - The pain state sets the recently-hit flag, causing the enemy to retaliate immediately on recovery
   - Pain state duration is very short (6 ticks for the basic trooper)
   - Being damaged also sets reaction time to 0 (immediate attack readiness)
   - If the enemy was idle (spawn state) when hit, it transitions to chase
@@ -215,7 +215,7 @@ Enemies in the classic reference FPS share a common AI framework built around a 
 
 - **Distance-based attack probability replaces explicit cooldowns**: Instead of putting attacks on a timer, the game makes distant enemies probabilistically less likely to fire. This creates natural-feeling attack patterns that are dense up close and sparse at range, without any visible "reloading" behavior.
 
-- **No double attack rule prevents stunlock**: The MF_JUSTATTACKED flag ensures an enemy always takes at least one chase step between attacks. On non-Nightmare difficulty, this means the enemy must also pick a new direction, creating visible wind-up before the next shot.
+- **No double attack rule prevents stunlock**: The post-attack flag (set after a monster fires and cleared on the next AI tick) ensures an enemy always takes at least one chase step between attacks. On non-Nightmare difficulty, this means the enemy must also pick a new direction, creating visible wind-up before the next shot.
 
 ## Enemy Constants Summary
 

--- a/tooling/agents/extractor.md
+++ b/tooling/agents/extractor.md
@@ -21,7 +21,7 @@ Before doing anything else:
 
 2. If `reference/` contains source files, proceed. Cite specific paths under `reference/` in your private notes — knowledge files themselves stay sanitized per § Output Rules below.
 
-`tooling/validate_specs.py` enforces this mechanically: it fails the run if `reference/` is empty AND `knowledge/` has any uncommitted changes. Trust the gate; do not work around it.
+`tooling/validate_specs.py` enforces two hard rules mechanically: (a) it fails the run if `reference/` is empty AND `knowledge/` has any uncommitted changes, and (b) it fails the run if ANY committed `knowledge/*.md` contains a forbidden source-identifier token. There is no warning-only path for either rule. Trust the gate; do not work around it.
 
 ## Mission
 

--- a/tooling/check_sanitization.py
+++ b/tooling/check_sanitization.py
@@ -252,7 +252,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--all",
         action="store_true",
-        help="Scan every *.md file in knowledge/ (excluding README.md).",
+        help="Scan every *.md file in knowledge/.",
     )
     parser.add_argument(
         "--mode",
@@ -275,7 +275,7 @@ def main() -> None:
     args = parse_args()
 
     if args.all:
-        paths = sorted(p for p in KNOWLEDGE_DIR.glob("*.md") if p.name != "README.md")
+        paths = sorted(KNOWLEDGE_DIR.glob("*.md"))
     else:
         paths = args.paths
 

--- a/tooling/validate_specs.py
+++ b/tooling/validate_specs.py
@@ -386,73 +386,36 @@ def validate_reference_knowledge_integrity() -> List[ValidationIssue]:
 # ---------------------------------------------------------------------------
 #
 # Forbidden-token detection lives in `tooling/check_sanitization.py` (the
-# single source of truth). This validator wraps it with a "soft" rule for
-# committed knowledge files (warn-but-allow — these are pre-existing tech
-# debt from before the gate existed, slated for cleanup) and a "hard" rule
-# for new or modified knowledge files (fail — every new extraction must
-# pass the gate clean).
+# single source of truth). Any leak in a `knowledge/*.md` file is a hard
+# validation error: the public knowledge artifact must be source-identifier
+# clean regardless of whether the offending file is committed or freshly
+# modified.
 
 CHECK_SANITIZATION_SCRIPT = REPO_ROOT / "tooling" / "check_sanitization.py"
 CHECK_ORPHAN_FILES_SCRIPT = REPO_ROOT / "tooling" / "check_orphan_files.py"
 
 
-def _run_sanitization(paths: Sequence[Path]) -> int:
-    """Invoke the script against `paths`. Returns its exit code."""
-    if not paths:
-        return 0
-    cmd = [sys.executable, str(CHECK_SANITIZATION_SCRIPT)] + [str(p) for p in paths]
-    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
-    if result.stderr:
-        print(result.stderr, file=sys.stderr, end="")
-    return result.returncode
-
-
 def validate_knowledge_sanitization() -> List[ValidationIssue]:
-    """Run the sanitization gate over knowledge/.
-
-    - Committed knowledge files: soft (warn-only). Pre-existing leaks are tech
-      debt and don't break the build.
-    - Uncommitted (modified or new) knowledge files: hard (fail). Every new
-      extraction must pass the gate.
-    """
+    """Fail validation if any `knowledge/*.md` file has a forbidden token."""
     if not CHECK_SANITIZATION_SCRIPT.exists():
         return []
 
-    all_files = sorted(p for p in KNOWLEDGE_DIR.glob("*.md") if p.name != "README.md")
+    all_files = sorted(KNOWLEDGE_DIR.glob("*.md"))
     if not all_files:
         return []
 
-    dirty_paths = set(knowledge_has_uncommitted_changes())
-    dirty_files = [p for p in all_files if str(p.relative_to(REPO_ROOT)) in dirty_paths]
-    committed_files = [p for p in all_files if str(p.relative_to(REPO_ROOT)) not in dirty_paths]
-
-    # Soft pass over committed files — warn-only.
-    if committed_files:
-        soft_rc = _run_sanitization(committed_files)
-        if soft_rc != 0:
-            print(
-                "\nNOTE: pre-existing sanitization leaks in COMMITTED knowledge files "
-                "above are warnings only (parking-lot for cleanup, not blocking).\n",
-                file=sys.stderr,
-            )
-
-    # Hard pass over uncommitted files — fail on any leak.
-    if dirty_files:
-        hard_rc = _run_sanitization(dirty_files)
-        if hard_rc != 0:
-            issues = [
-                ValidationIssue(
-                    KNOWLEDGE_DIR,
-                    "uncommitted knowledge files have sanitization leaks — see "
-                    "tooling/check_sanitization.py output above. New extractions "
-                    "must pass the gate clean.",
-                )
-            ]
-            for p in dirty_files:
-                issues.append(ValidationIssue(p, "uncommitted file with sanitization leak"))
-            return issues
-
-    return []
+    cmd = [sys.executable, str(CHECK_SANITIZATION_SCRIPT)] + [str(p) for p in all_files]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if result.stderr:
+        print(result.stderr, file=sys.stderr, end="")
+    if result.returncode == 0:
+        return []
+    return [
+        ValidationIssue(
+            KNOWLEDGE_DIR,
+            "sanitization leak — see tooling/check_sanitization.py output above",
+        )
+    ]
 
 
 def validate_orphan_files() -> List[ValidationIssue]:


### PR DESCRIPTION
Paraphrases forbidden tokens out of `knowledge/combat_balance.md` and `knowledge/enemy_types.md`, then collapses the soft-pass in `tooling/validate_specs.py` so future sanitization failures block validation instead of falling through as warnings.

Public knowledge artifact honesty is core per CLAUDE.md "Reference and Knowledge Integrity"; today the gate let leaks live for months as a parking-lot.