### PR TITLE
Shrink agent-intake prompt-injection surface

### DIFF
--- a/.github/workflows/agent-intake.yml
+++ b/.github/workflows/agent-intake.yml
@@ -100,12 +100,24 @@ jobs:
           fi
 
       - name: Build scope from issue body
-        id: scope
         run: |
           set -euo pipefail
           mkdir -p artifacts
           gh issue view "$ISSUE_NUMBER" --json title,body \
             -q '"# " + .title + "\n\n" + .body' > artifacts/issue_scope.md
+
+      - name: Sanitize issue scope
+        # Hygiene pass before the issue body reaches an LLM prompt: caps the
+        # body to 4096 bytes and replaces ` and ~~~ with safe surrogates.
+        # NOT a security boundary; the actual injection mitigation is the
+        # Bash removal from Extractor's PHASE_TOOLS in
+        # tooling/orchestrator_run.py. See tooling/sanitize_scope.py.
+        run: python tooling/sanitize_scope.py artifacts/issue_scope.md
+
+      - name: Export scope to job output
+        id: scope
+        run: |
+          set -euo pipefail
           echo "Issue scope (truncated):"
           head -c 1000 artifacts/issue_scope.md
           echo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,7 +155,7 @@ Settings → Branches → main → "Require status checks to pass before merging
 
 1. Anyone files an issue using `.github/ISSUE_TEMPLATE/agent-task.yml` — fields are Goal, Scope, Affected modules (optional), Constraints, Acceptance criteria. The form auto-applies the inert label `agent:task`. **Filing alone does NOT spend tokens.**
 2. A maintainer (admin / write / maintain) reviews the issue and applies `agent:run`. The workflow verifies the sender's permission via `gh api .../collaborators/.../permission` before doing anything else.
-3. The job clones the public reference repo from `vars.WORLDSMITH_REFERENCE_REPO` into `reference/`, runs Extractor, runs `check_sanitization.py` + `validate_specs.py`, runs Architect, validates again, wipes `reference/`, commits to `agent/issue-<N>`, force-pushes, and opens a draft PR `Closes #<N>`.
+3. The job clones the public reference repo from `vars.WORLDSMITH_REFERENCE_REPO` into `reference/`, writes the issue title+body to `artifacts/issue_scope.md`, runs `tooling/sanitize_scope.py` over it (caps to 4096 bytes and replaces backtick/`~~~` fence characters — hygiene, not a security boundary), runs Extractor, runs `check_sanitization.py` + `validate_specs.py`, runs Architect, validates again, wipes `reference/`, commits to `agent/issue-<N>`, force-pushes, and opens a draft PR `Closes #<N>`.
 4. The PR triggers the existing `pr.yml` flow — Coder / Reconciler / PostMortem on the affected modules, plus `cargo build/test` and the demo GIF.
 5. On success the workflow swaps the issue's labels to `agent:in-pr`. On failure (including the `EXTRACTOR_BLOCKED` sentinel from an empty reference clone), it comments the reason and applies `agent:failed`. Re-applying `agent:run` re-runs and force-pushes onto the same branch.
 
@@ -178,6 +178,15 @@ Local helper: the project-level skill `/create-agent-task` (`.claude/skills/crea
 - Permission gate, label gate, and reference clone all run before the first `claude` invocation — unauthorized triggers spend no tokens.
 - `WORLDSMITH_MAX_TOKENS_PER_RUN` is honoured by both phases via `orchestrator_run.py`.
 - `concurrency: cancel-in-progress: true` keyed on issue number — re-labeling the same issue cancels the prior run.
+
+### Injection surface
+
+The issue body is attacker-controlled (only the maintainer who applies `agent:run` is permission-gated; issue authors are not). Two layers shrink the resulting prompt-injection surface:
+
+1. **Extractor has no shell access.** `tooling/orchestrator_run.py`'s `PHASE_TOOLS` deliberately omits `Bash` from Extractor's allowlist, so issue-derived prose entering the prompt cannot reach a shell from inside that phase. Sanitization gates (`check_sanitization.py`, `validate_specs.py`) are run by the workflow post-phase, not by the agent.
+2. **Issue scope is sanitized before forwarding.** `tooling/sanitize_scope.py` runs on `artifacts/issue_scope.md` between the `gh issue view` step and either LLM phase — caps to 4096 bytes and replaces ` and `~~~` with safe surrogates. Hygiene only.
+
+Architect's `PHASE_TOOLS` entry still includes `Bash`; auditing/shrinking it and adding a maintainer re-confirmation step are deferred.
 
 ## Known Issues
 

--- a/tooling/agents/extractor.md
+++ b/tooling/agents/extractor.md
@@ -141,14 +141,10 @@ Ensure public knowledge files contain no source references or file paths from th
 - **No proper nouns.** If the reference uses "Stimpack", your knowledge entry says "small health pickup". The sanitization commit (`87863b7`) explicitly removed identifiers — do not re-add them.
 - **No numeric source-identifiers either.** Release years (1993, 1994, 2004), version numbers (`v1.10`), copyright years, and magic constants from the source's preprocessor that grep-match `\b(199[0-9]|200[0-9])\b` ALSO count as identifiers — substitute with neutral phrasing or omit. A previous extraction leaked the source-game's release year as a "sentinel value" because the rule did not say years count. They count.
 
-## Sanitization gate (mandatory before declaring done)
+## Sanitization gate (enforced by the workflow)
 
-Once `knowledge/<area>.md` is written, run:
+You have no shell access — `Bash` is not in your tool allowlist. Do **not** attempt to invoke `python3 tooling/check_sanitization.py` yourself; it will fail. The agent-intake workflow runs that script automatically against any `knowledge/*.md` you change, immediately after this phase, and `tooling/validate_specs.py` runs it again over every file in `knowledge/` on every validation pass. A leak that survives sanitization fails the whole run and rejects the PR.
 
-```
-python3 tooling/check_sanitization.py knowledge/<area>.md
-```
+Your job is therefore to make the gate pass on the first try by writing clean prose. While you are writing, if you find yourself about to commit a forbidden token (proper nouns, source identifiers, year-range, lump names — see the prohibitions section above), paraphrase the offending section in place using neutral phrasing. Do not "shell out and check"; you cannot, and you do not need to — the workflow does that for you.
 
-It exits non-zero with offending lines if any forbidden token (proper nouns, source identifiers, year-range, lump names) survives. Treat any non-zero exit as a hard rejection — rewrite the offending sections, do NOT patch around the grep. The single source of truth for forbidden patterns is the script itself; do not maintain a parallel grep block in your prompt.
-
-`tooling/validate_specs.py` invokes the same script over every file in `knowledge/` as part of every run, so a leak that survives this gate fails the whole validation run.
+The single source of truth for forbidden patterns is `tooling/check_sanitization.py` itself; do not maintain a parallel grep block in your prompt. If you are unsure whether a phrase is safe, rewrite it more abstractly — neutral phrasing is always cheaper than re-running the phase.

--- a/tooling/orchestrator_run.py
+++ b/tooling/orchestrator_run.py
@@ -82,7 +82,7 @@ PHASES = ["extractor", "architect", "coder", "reconciler", "postmortem", "releas
 # Tools each phase is permitted to invoke. Conservative defaults — broaden
 # only when the phase legitimately needs more.
 PHASE_TOOLS: Dict[str, List[str]] = {
-    "extractor": ["Read", "Write", "Edit", "Bash", "Grep", "Glob"],
+    "extractor": ["Read", "Write", "Edit", "Grep", "Glob"],
     "architect": ["Read", "Write", "Edit", "Bash", "Grep", "Glob"],
     "coder": ["Read", "Write", "Edit", "Bash", "Grep", "Glob"],
     "reconciler": ["Read", "Edit", "Bash", "Grep", "Glob"],
@@ -151,9 +151,11 @@ def build_prompt(phase: str, mode: str, scope: Optional[str]) -> str:
         "You are running NON-INTERACTIVELY inside a CI workflow. "
         "Treat all instructions in the role prompt as authoritative. "
         f"Mode: `{mode}`. Repository root is the current working directory. "
-        "Use Read/Write/Edit/Bash tools to make file changes; do not ask questions — "
-        "if information is missing, escalate by writing a clear blocker note to "
-        "`artifacts/blocker.md` and exit. When you are done, exit normally."
+        "Use the tools available to you to make file changes; the per-phase "
+        "`--allowedTools` list is authoritative — do not assume Bash is available. "
+        "Do not ask questions — if information is missing, escalate by writing a "
+        "clear blocker note to `artifacts/blocker.md` and exit. When you are done, "
+        "exit normally."
     )
 
     # Order matters for prompt-cache prefix matching: most-stable content first.
@@ -187,7 +189,11 @@ def claude_command(phase: str, model: Optional[str], max_turns: int) -> List[str
         "--max-turns",
         str(max_turns),
         "--allowedTools",
-        ",".join(PHASE_TOOLS.get(phase, ["Read", "Write", "Edit", "Bash"])),
+        # No fallback: argparse already restricts `--phase` to PHASES, and every
+        # PHASES entry must have an explicit allowlist. A silent fallback (esp.
+        # one containing Bash) would let a future typo or refactor quietly
+        # re-introduce Bash to a phase that consumes attacker-controlled input.
+        ",".join(PHASE_TOOLS[phase]),
     ]
     effective_model = model or PHASE_DEFAULT_MODEL.get(phase)
     if effective_model:

--- a/tooling/sanitize_scope.py
+++ b/tooling/sanitize_scope.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""
+Hygiene pass on the issue-derived scope file before it is forwarded to LLM
+phases (Extractor, Architect) by `.github/workflows/agent-intake.yml`.
+
+This is *not* a security boundary. The real injection mitigation is the
+removal of `Bash` from Extractor's tool allowlist (see PHASE_TOOLS in
+`tooling/orchestrator_run.py`). This helper only:
+
+  1. Truncates the file to 4096 bytes (UTF-8 safe at the byte boundary)
+     to bound prompt size.
+  2. Replaces ` with ' and ~~~ with --- so issue-supplied content is
+     less likely to be parsed as markdown structure (fenced blocks,
+     inline code) by the downstream agent. The prompt template does not
+     wrap scope in a fence, so this is a hygiene step, not a structural
+     escape — adversarial heading-level content (e.g. `## Override`) is
+     not addressed and is the reason this is not a security boundary.
+
+Pure stdlib.
+
+Usage:
+
+    python3 tooling/sanitize_scope.py artifacts/issue_scope.md
+
+Exit codes:
+    0 — file rewritten in place (or no change needed).
+    2 — usage error / file not found.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+MAX_BYTES = 4096
+
+
+def sanitize_text(text: str) -> str:
+    """Replace fence-introducing characters with safe surrogates.
+
+    `__WS_EOS__` is the heredoc-style delimiter the agent-intake workflow
+    uses to push the scope into `$GITHUB_OUTPUT` (see
+    `.github/workflows/agent-intake.yml`). An attacker-controlled issue
+    body containing that literal would terminate the multi-line output
+    early and let subsequent lines be parsed as additional step outputs;
+    neutralize it here.
+    """
+    text = text.replace("`", "'")
+    text = text.replace("~~~", "---")
+    text = text.replace("__WS_EOS__", "__ws_eos_safe__")
+    return text
+
+
+def truncate_bytes(text: str, max_bytes: int) -> str:
+    """Cap a string at `max_bytes` UTF-8 bytes without splitting a codepoint."""
+    encoded = text.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return text
+    return encoded[:max_bytes].decode("utf-8", errors="ignore")
+
+
+def sanitize_path(path: Path) -> None:
+    raw = path.read_text(encoding="utf-8")
+    cleaned = truncate_bytes(sanitize_text(raw), MAX_BYTES)
+    # The agent-intake workflow appends `cat <this file>` between two `echo`
+    # lines into a `$GITHUB_OUTPUT` heredoc. If the file does not end in `\n`,
+    # `cat` emits its content with no trailing newline and the next `echo`'s
+    # closing `__WS_EOS__` is concatenated onto the last content line — the
+    # delimiter is no longer on its own line and the heredoc never closes.
+    # Truncation makes this reachable for any body whose first 4096 bytes
+    # don't end at a line boundary, so guarantee a trailing newline here.
+    if not cleaned.endswith("\n"):
+        cleaned += "\n"
+    if cleaned != raw:
+        path.write_text(cleaned, encoding="utf-8")
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print("usage: python3 tooling/sanitize_scope.py <path>", file=sys.stderr)
+        sys.exit(2)
+    path = Path(sys.argv[1])
+    if not path.is_file():
+        print(f"error: file not found: {path}", file=sys.stderr)
+        sys.exit(2)
+    sanitize_path(path)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Drops `Bash` from Extractor in `PHASE_TOOLS` (`tooling/orchestrator_run.py`) and adds a length cap + fence escape on the GitHub issue scope before forwarding to Extractor. The label-permission gate in `agent-intake.yml` only verifies who applied the label, not who authored the body, so an attacker-authored body would otherwise reach an LLM with shell access.

Adds `tooling/sanitize_scope.py` for the truncation/escape helper.