### PR TITLE
Add pr-assets cleanup workflow

### DIFF
--- a/.github/workflows/pr-assets-cleanup.yml
+++ b/.github/workflows/pr-assets-cleanup.yml
@@ -1,0 +1,70 @@
+name: pr-assets cleanup
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: pr-assets-cleanup-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    name: cleanup
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check pr-assets branch exists
+        id: branch-check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -e
+          # Distinguish a real 404 (benign no-op) from transient 403/429/5xx,
+          # auth failures, or network errors — those must fail the workflow,
+          # not silently leave pr-assets files behind.
+          set +e
+          err=$(gh api "/repos/${REPO}/branches/pr-assets" 2>&1 >/dev/null)
+          rc=$?
+          set -e
+          if [ "$rc" -eq 0 ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          elif printf '%s' "$err" | grep -q "HTTP 404"; then
+            echo "pr-assets branch does not exist; nothing to clean up."
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "gh api failed checking pr-assets branch (exit ${rc}): ${err}" >&2
+            exit "$rc"
+          fi
+
+      - name: Delete demo gifs for closed PR
+        if: steps.branch-check.outputs.exists == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -e
+          PREFIX="pr-${PR}-"
+          # Contents API directory listings return up to 1000 entries in one
+          # response (no Link-header pagination). If pr-assets ever exceeds
+          # that, switch to the Git Trees API.
+          gh api "/repos/${REPO}/contents?ref=pr-assets" \
+            --jq ".[] | select(.type == \"file\") | select(.name | startswith(\"${PREFIX}\")) | select(.name | endswith(\"-demo.gif\")) | \"\\(.path)\t\\(.sha)\"" \
+            > /tmp/matches.tsv
+          COUNT=0
+          while IFS=$'\t' read -r p sha; do
+            [ -z "$p" ] && continue
+            gh api --method DELETE "/repos/${REPO}/contents/${p}" \
+              -f message="Cleanup PR #${PR} demo gif: ${p}" \
+              -f branch=pr-assets \
+              -f sha="${sha}" > /dev/null
+            echo "Deleted ${p}"
+            COUNT=$((COUNT + 1))
+          done < /tmp/matches.tsv
+          rm -f /tmp/matches.tsv
+          echo "Removed ${COUNT} gif(s) for PR #${PR}."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,7 @@ Workflow: `Reference → Extractor → knowledge/ → Architect → specs/ → C
   6. Record `release/demo.gif` via `tooling/record_autopilot.sh`.
   7. Reconciler's edits to `specs/`, `knowledge/`, `ir/`, `tooling/agents/` and PostMortem's surgical edits to `tooling/agents/*.md` are captured as a unified diff and posted as **inline review suggestions** via `reviewdog/action-suggester` (only on lines this PR already touches; the rest of the diff is in the `agent_changes.diff` artifact).
   8. PostMortem's narrative analysis (run summary, "what hurt", ADR drafts) is saved to `artifacts/postmortem.md` and linked from the PR comment.
-  9. The demo GIF is uploaded to a single shared `pr-assets` branch (auto-created on first run from `main`'s HEAD) as `pr-<N>-run-<run_id>-demo.gif`, then embedded inline in the PR status comment via its `raw.githubusercontent.com` URL. PR number + run id make filenames unique, so concurrent PR runs don't race. The branch is **never automatically pruned** — see Known Issues for cleanup.
+  9. The demo GIF is uploaded to a single shared `pr-assets` branch (auto-created on first run from `main`'s HEAD) as `pr-<N>-run-<run_id>-demo.gif`, then embedded inline in the PR status comment via its `raw.githubusercontent.com` URL. PR number + run id make filenames unique, so concurrent PR runs don't race. Cleanup runs via `.github/workflows/pr-assets-cleanup.yml` on `pull_request: closed`, deleting every `pr-<N>-*-demo.gif` for the closed PR. The cleanup filter requires both `startswith("pr-<N>-")` and `endswith("-demo.gif")` — keep this paired with the upload filename above (or extend the filter when adding a new artifact suffix).
 
 ### Post-merge snapshot (`generated-snapshot` branch)
 
@@ -142,6 +142,8 @@ Settings → Branches → main → "Require status checks to pass before merging
 - Required: `regenerate-and-build`
 
 `regenerate-and-build` is conditionally `if:`-skipped on fork PRs and on PRs that don't touch source-of-truth paths. GitHub treats a skipped job as a passing required check, so skipping doesn't block merge. A skipped check on a fork PR means the maintainer must rerun the workflow from this repo's branch (or close-and-reopen as a maintainer) to actually validate regeneration before merging.
+
+Do **not** add `pr-assets cleanup` as a required check. It triggers on `pull_request: types: [closed]`, so it runs after merge — making it required would deadlock every PR (the gating check can never reach success before the merge button does).
 
 ### Cost control
 
@@ -182,5 +184,4 @@ Local helper: the project-level skill `/create-agent-task` (`.claude/skills/crea
 ## Known Issues
 
 - Top-down view, not raycasting
-- The shared `pr-assets` branch grows by one file per PR run and is never pruned automatically. Periodic cleanup is needed — either a cron workflow that drops files older than N days, or a `pull_request: types: [closed]` workflow that deletes `pr-<N>-*.gif` for the closed PR. Not implemented yet.
 - The `generated-snapshot` branch is force-pushed and orphan-committed each time, so historical snapshots are not retained — only the latest regen-merge baseline lives there. If you need a previous baseline, fall back to the corresponding GitHub Release's `worldsmith-game-X-src.zip`. If a PR sits open for more than 90 days, its `generated-src` artifact expires and the post-merge snapshot can no longer pick it up — `post-merge-snapshot.yml` warns and skips, leaving the previous snapshot in place; refresh manually via `release.yml` if needed.


### PR DESCRIPTION
Adds `.github/workflows/pr-assets-cleanup.yml` triggered on `pull_request: closed` that deletes `pr-<N>-*.gif` from the long-lived `pr-assets` branch via the GitHub Contents API. Closes the gap self-acknowledged in CLAUDE.md "Known Issues".

Cron belt-and-suspenders for race-orphan files (PR closed before `pr.yml` finished pushing the gif) is left for a follow-up.