### PR TITLE
Demote smoke checklist to manual runbook

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -37,8 +37,8 @@ Evals test the **harness** (generation pipeline), not the game itself.
 ```
 evals/
 ├── README.md               # This file
-├── smoke/                  # Quick checks after any change
-│   └── smoke_checklist.md
+├── smoke/                  # Manual pre-release runbook (not scripted)
+│   └── manual_smoke_checklist.md
 ├── generation/             # Pipeline evals
 │   ├── builds.md
 │   └── reproducibility.md
@@ -74,8 +74,8 @@ Release criteria are defined by the specs at that git tag, not by separate versi
 | Trigger | Which evals |
 |---------|-------------|
 | After spec change | `specs/` |
-| After generation | `generation/`, `smoke/` |
-| Before release (git tag) | All evals must pass |
+| After generation | `generation/` |
+| Before release (git tag) | All evals must pass + walk the `smoke/` runbook |
 | After agent run | `agents/` |
 
 ## Background

--- a/evals/smoke/manual_smoke_checklist.md
+++ b/evals/smoke/manual_smoke_checklist.md
@@ -1,9 +1,8 @@
-# Smoke Checklist
+# Manual Smoke Checklist
 
-## Automated (via `python tooling/run_evals.py`)
+This is a manual pre-release runbook, not a scripted eval. The scripted smoke pipeline is `cargo build` + `cargo test`, run via `tooling/run_evals.py`. Run this checklist before tagging a release.
 
-- [x] project builds (`cargo build`)
-- [x] all tests pass (`cargo test`)
+Automated coverage: see `tooling/run_evals.py`.
 
 ## Manual Testing
 

--- a/tooling/run_evals.py
+++ b/tooling/run_evals.py
@@ -7,6 +7,9 @@ Runs automated checks:
 2. cargo test - all tests pass
 3. cargo clippy - no warnings (optional)
 
+Manual pre-release smoke is documented separately at
+evals/smoke/manual_smoke_checklist.md and is not invoked by this script.
+
 Usage:
     python tooling/run_evals.py [--clippy]
 """


### PR DESCRIPTION
Renames `evals/smoke/smoke_checklist.md` to `manual_smoke_checklist.md`, rewrites the top to mark it clearly as a manual pre-release runbook (not a scripted eval), and updates references in `evals/README.md` and `tooling/run_evals.py`. The `[ ]` checkboxes were never executed by anything; this fixes the framing without trying to mechanize headed-display checks.