### PR TITLE
agent-intake: lint issue scope before Claude CLI install

### DIFF
--- a/.github/workflows/agent-intake.yml
+++ b/.github/workflows/agent-intake.yml
@@ -61,6 +61,50 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt
 
+      - name: Lint issue scope
+        id: lint
+        env:
+          REF_REPO: ${{ env.REFERENCE_REPO }}
+        run: |
+          set -euo pipefail
+          gh issue view "$ISSUE_NUMBER" --json body -q .body > /tmp/issue_body.md
+          set +e
+          python tooling/check_issue_scope.py < /tmp/issue_body.md > /tmp/lint_verdict.json
+          LINT_CODE=$?
+          set -e
+          echo "verdict_code=${LINT_CODE}" >> "$GITHUB_OUTPUT"
+          echo "Linter verdict (exit ${LINT_CODE}):"
+          cat /tmp/lint_verdict.json
+          if [ "$LINT_CODE" = "1" ]; then
+            {
+              echo "**Issue rejected by \`tooling/check_issue_scope.py\`** before any token spend:"
+              echo
+              jq -r '.hard[] | "- " + .' /tmp/lint_verdict.json
+              if [ "$(jq '.soft | length' /tmp/lint_verdict.json)" != "0" ]; then
+                echo
+                echo "Soft warnings that would also have been raised:"
+                jq -r '.soft[] | "- " + .' /tmp/lint_verdict.json
+              fi
+              echo
+              echo "After addressing, re-apply the \`agent:run\` label."
+            } > /tmp/lint_comment.md
+            gh issue comment "$ISSUE_NUMBER" --body-file /tmp/lint_comment.md
+            gh issue edit "$ISSUE_NUMBER" --remove-label "agent:run" --add-label "agent:failed"
+          elif [ "$LINT_CODE" = "2" ]; then
+            {
+              echo "**Soft warnings from \`tooling/check_issue_scope.py\`** (proceeding):"
+              echo
+              jq -r '.soft[] | "- " + .' /tmp/lint_verdict.json
+            } > /tmp/lint_comment.md
+            gh issue comment "$ISSUE_NUMBER" --body-file /tmp/lint_comment.md
+          fi
+
+      - name: Block if lint hard-rejected
+        if: steps.lint.outputs.verdict_code == '1'
+        run: |
+          echo "::error::Linter hard-rejected this issue (see issue comment)."
+          exit 1
+
       - name: Install Claude CLI
         run: |
           set -e
@@ -251,7 +295,10 @@ jobs:
           esac
 
       - name: Comment on issue (failure)
-        if: failure()
+        # Skip when the linter already commented + relabeled — avoids a
+        # duplicate "Agent run failed" message on top of the structured
+        # rejection from `tooling/check_issue_scope.py`.
+        if: failure() && steps.lint.outputs.verdict_code != '1'
         run: |
           REASON="failed at a step. See run https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           if [ "${{ steps.extractor.outputs.blocked }}" = "true" ]; then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,6 +180,7 @@ Local helper: the project-level skill `/create-agent-task` (`.claude/skills/crea
 ### Cost control
 
 - Permission gate, label gate, and reference clone all run before the first `claude` invocation — unauthorized triggers spend no tokens.
+- `tooling/check_issue_scope.py` runs immediately after Python setup, before the Claude CLI install and reference clone. Hard-rejects issues that bundle >2 modules in `Affected modules` or mandate knowledge backing while the reference repo is empty (the two failure modes that drove PR #28's 17-regen cycle); soft-warns on multi-track Goal phrasing or empty modules field. On hard-reject the workflow comments the structured reason on the issue, swaps `agent:run` → `agent:failed`, and exits — zero token spend on Claude. Tests: `python3 -m unittest tooling/check_issue_scope_test.py`.
 - `WORLDSMITH_MAX_TOKENS_PER_RUN` is honoured by both phases via `orchestrator_run.py`.
 - `concurrency: cancel-in-progress: true` keyed on issue number — re-labeling the same issue cancels the prior run.
 

--- a/tooling/check_issue_scope.py
+++ b/tooling/check_issue_scope.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Lint an agent-task issue body for known over-scope / deadlock patterns.
+
+Reads the issue body from stdin. Emits a JSON verdict to stdout.
+
+Exit codes:
+  0  pass
+  1  hard reject  (workflow should block)
+  2  soft warn    (workflow should comment but proceed)
+
+Rules and rationale: work/ideas/2026-05-09_constraint_linter.md.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from typing import List, Tuple
+
+MAX_MODULES = 2
+
+KNOWLEDGE_MANDATE_PATTERNS = [
+    r"knowledge[- ]backed",
+    r"MUST cite knowledge",
+    r"MUST trace to knowledge",
+    r"must be knowledge[- ]backed",
+    r"knowledge/[\w./-]+\.md",
+]
+
+VERB_JOINERS = (" and ", " plus ", " also ", ", and ", ", plus ")
+VERB_COUNT_THRESHOLD = 3
+
+EMPTY_MODULE_MARKERS = {"", "—", "-", "none.", "none", "n/a", "tbd"}
+
+MODULE_STOPWORDS = {
+    "optional", "and", "or", "the", "a", "an",
+    "modules", "module", "none", "n", "a",
+}
+
+
+def parse_section(body: str, heading: str) -> str:
+    """Extract content under a `### heading` marker (case-insensitive)."""
+    pattern = rf"###\s+{re.escape(heading)}\s*\n(.*?)(?=\n###\s|\Z)"
+    m = re.search(pattern, body, re.DOTALL | re.IGNORECASE)
+    return m.group(1).strip() if m else ""
+
+
+def count_modules(body: str) -> int:
+    section = parse_section(body, "Affected modules")
+    if not section or section.strip().lower() in EMPTY_MODULE_MARKERS:
+        return 0
+    tokens = re.findall(r"[a-z_][a-z0-9_]*", section.lower())
+    return len([t for t in tokens if t not in MODULE_STOPWORDS])
+
+
+def has_knowledge_mandate(body: str) -> bool:
+    return any(re.search(p, body, re.IGNORECASE) for p in KNOWLEDGE_MANDATE_PATTERNS)
+
+
+def reference_repo_empty() -> bool:
+    """True if the reference repo (per REF_REPO env var) has no refs.
+
+    Treat any failure (no env var, network error, no refs) as empty so the
+    knowledge-mandate gate fires whenever the reference is unreachable. The
+    caller can override this by populating reference/ before triggering.
+    """
+    repo = os.environ.get("REF_REPO", "").strip()
+    if not repo:
+        return True
+    try:
+        r = subprocess.run(
+            ["git", "ls-remote", "--refs", repo],
+            capture_output=True, timeout=10, text=True,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return True
+    return r.returncode != 0 or not r.stdout.strip()
+
+
+def goal_track_count(body: str) -> int:
+    """Count distinct tracks in the Goal first paragraph via joiner heuristic."""
+    section = parse_section(body, "Goal")
+    if not section:
+        return 0
+    first_para = section.split("\n\n")[0].lower()
+    joiner_hits = sum(first_para.count(j) for j in VERB_JOINERS)
+    return joiner_hits + 1
+
+
+def lint(body: str) -> Tuple[int, List[str], List[str]]:
+    """Return (exit_code, hard_reasons, soft_reasons)."""
+    hard: List[str] = []
+    soft: List[str] = []
+
+    n_modules = count_modules(body)
+    if n_modules > MAX_MODULES:
+        hard.append(
+            f"`Affected modules` lists {n_modules} modules. Bundles of "
+            f">{MAX_MODULES} modules historically take 13+ regens to land "
+            f"(PR #28 post-mortem). Split into {n_modules} focused issues; "
+            f"the agent-intake will run each in <2 regens."
+        )
+
+    if has_knowledge_mandate(body) and reference_repo_empty():
+        hard.append(
+            "Issue mandates knowledge backing (matched a knowledge-mandate "
+            "phrase) but the reference repo is empty or unreachable. Either "
+            "populate `reference/`, drop the knowledge requirement, or mark "
+            "affected values upfront as `Generation default — no knowledge "
+            "backing` in the issue body. Issue #26 hit this exact deadlock."
+        )
+
+    n_tracks = goal_track_count(body)
+    if n_tracks >= VERB_COUNT_THRESHOLD:
+        soft.append(
+            f"Goal first paragraph appears to combine {n_tracks} distinct "
+            f"tracks (joined by 'and'/'plus'/'also'). Consider splitting "
+            f"before running. (Soft warning, not a block.)"
+        )
+
+    if n_modules == 0:
+        soft.append(
+            "`Affected modules` is empty. Pipeline will run a full release "
+            "regen for this issue (~5x more tokens than partial regen). If "
+            "you intended a narrow scope, add the field."
+        )
+
+    if hard:
+        return 1, hard, soft
+    if soft:
+        return 2, hard, soft
+    return 0, hard, soft
+
+
+def main() -> int:
+    body = sys.stdin.read()
+    code, hard, soft = lint(body)
+    verdict = {0: "pass", 1: "hard_reject", 2: "soft_warn"}[code]
+    out = {
+        "verdict": verdict,
+        "hard": hard,
+        "soft": soft,
+    }
+    json.dump(out, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tooling/check_issue_scope_test.py
+++ b/tooling/check_issue_scope_test.py
@@ -1,0 +1,165 @@
+"""Stdlib-only unit tests for check_issue_scope.
+
+Run: `python3 -m unittest tooling/check_issue_scope_test.py`.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+LINTER = Path(__file__).resolve().parent / "check_issue_scope.py"
+
+
+def run_linter(body: str, ref_repo: str = "") -> tuple[int, dict]:
+    env = {**os.environ, "REF_REPO": ref_repo}
+    r = subprocess.run(
+        [sys.executable, str(LINTER)],
+        input=body, capture_output=True, text=True, env=env,
+    )
+    payload = json.loads(r.stdout) if r.stdout.strip() else {}
+    return r.returncode, payload
+
+
+# Issue body fixtures.
+# Each one exercises a specific rule documented in the linter source.
+
+PR26_LIKE_BODY = """\
+### Goal
+Replace the current minimalist default level with a richer real level whose
+geometry mirrors the reference's first map. Teach the smart autopilot bot to
+additionally route via the nearest active health pickup.
+
+### Scope
+Extractor phase. Load reference/. Capture the reference's first-map geometry
+into knowledge/first_map.md. Each entry must cite the source reference file.
+
+### Affected modules
+
+level_data, autopilot, main
+
+### Constraints
+The richer default level's geometry MUST be knowledge-backed. Each pinned
+coordinate must trace to a citation in knowledge/*.md.
+
+### Acceptance criteria
+- knowledge/ gains reference-cited entries
+- specs/25 rewritten with knowledge-backed Source citations
+"""
+
+GOOD_SINGLE_TRACK_BODY = """\
+### Goal
+Fix the kite-mode LoS gate in autopilot.
+
+### Scope
+Update `autopilot::compute_nav_target` kite condition to add a
+`has_line_of_sight` check.
+
+### Affected modules
+
+autopilot
+
+### Constraints
+None.
+
+### Acceptance criteria
+- `tests/level/local_chase_obstacle.yaml` runs without indefinite back-pedal.
+- `cargo test` passes.
+"""
+
+TWO_MODULES_NO_KNOWLEDGE_BODY = """\
+### Goal
+Add a stagger animation hook.
+
+### Scope
+Renderer reads a new `Enemy.stagger_remaining` field set by enemy_logic.
+
+### Affected modules
+
+enemy_logic, renderer
+
+### Constraints
+None.
+
+### Acceptance criteria
+- Tests pass.
+"""
+
+EMPTY_MODULES_BODY = """\
+### Goal
+Refactor the renderer.
+
+### Scope
+Touch some renderer code.
+
+### Affected modules
+
+—
+
+### Constraints
+None.
+
+### Acceptance criteria
+- Tests pass.
+"""
+
+MULTI_TRACK_GOAL_BODY = """\
+### Goal
+Refactor the renderer and add new pickup AI and update the demo source and
+document the variant policy.
+
+### Scope
+Touch some code.
+
+### Affected modules
+
+renderer
+
+### Constraints
+None.
+
+### Acceptance criteria
+- Tests pass.
+"""
+
+
+class LinterTests(unittest.TestCase):
+    def test_pr26_like_body_hard_rejects(self) -> None:
+        code, output = run_linter(PR26_LIKE_BODY, ref_repo="")
+        self.assertEqual(code, 1, output)
+        self.assertEqual(output["verdict"], "hard_reject")
+        joined = "\n".join(output["hard"])
+        self.assertIn("3 modules", joined)
+        self.assertIn("knowledge", joined.lower())
+
+    def test_good_single_track_body_passes(self) -> None:
+        code, output = run_linter(GOOD_SINGLE_TRACK_BODY, ref_repo="")
+        self.assertEqual(code, 0, output)
+        self.assertEqual(output["verdict"], "pass")
+        self.assertEqual(output["hard"], [])
+        self.assertEqual(output["soft"], [])
+
+    def test_two_modules_no_knowledge_passes(self) -> None:
+        code, output = run_linter(TWO_MODULES_NO_KNOWLEDGE_BODY, ref_repo="")
+        self.assertEqual(code, 0, output)
+        self.assertEqual(output["verdict"], "pass")
+
+    def test_empty_modules_soft_warns(self) -> None:
+        code, output = run_linter(EMPTY_MODULES_BODY, ref_repo="")
+        self.assertEqual(code, 2, output)
+        self.assertEqual(output["verdict"], "soft_warn")
+        self.assertEqual(output["hard"], [])
+        self.assertTrue(any("Affected modules" in r for r in output["soft"]))
+
+    def test_multi_track_goal_soft_warns(self) -> None:
+        code, output = run_linter(MULTI_TRACK_GOAL_BODY, ref_repo="")
+        self.assertEqual(code, 2, output)
+        self.assertEqual(output["verdict"], "soft_warn")
+        self.assertTrue(any("distinct tracks" in r for r in output["soft"]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Hard-rejects agent-task issues that bundle >2 modules in `Affected modules` or mandate knowledge backing while the reference repo is empty — before any Claude tokens are spent. These are the two failure modes that drove PR #28's 17-regen cycle (issue #26 listed three modules AND mandated knowledge backing on an empty reference; Architect deadlocked, maintainer completed by hand, Coder/Reconciler/PostMortem cycled for two days).

The new step runs after `Set up Python` but before `Install Claude CLI` + `Clone reference corpus`, so an unauthorized or malformed trigger spends nothing past Python setup.

`tooling/check_issue_scope.py` reads the issue body from stdin, emits JSON verdict with exit codes 0 (pass) / 1 (hard reject) / 2 (soft warn). Hard rejects: >2 modules; knowledge mandate on empty reference. Soft warns: 3+ tracks in Goal joined by `and`/`plus`/`also`; empty `Affected modules` (forces full release regen, ~5x more tokens than partial).

On hard-reject the linter posts a structured comment listing the reasons, swaps `agent:run` → `agent:failed`, and the next step exits 1. The existing failure-comment step is suppressed via `steps.lint.outputs.verdict_code != '1'` to avoid a duplicate "Agent run failed" message on top of the structured rejection.

Five stdlib `unittest` tests in `tooling/check_issue_scope_test.py` cover both hard-reject paths, both soft-warn paths, and a clean-pass case. No new pip dependency. Run with `python3 -m unittest tooling/check_issue_scope_test.py`.

Plan + rationale: `work/ideas/2026-05-09_constraint_linter.md` (gitignored).

Pairs with a follow-up PR that extends `/create-agent-task` skill with a draft-time decomposition prompt — server-side gate (this PR) + client-side coach.