### PR TITLE
create-agent-task skill: decomposition check at draft time

### DIFF
--- a/.claude/skills/create-agent-task/SKILL.md
+++ b/.claude/skills/create-agent-task/SKILL.md
@@ -41,9 +41,25 @@ Goal: produce a complete issue body matching `.github/ISSUE_TEMPLATE/agent-task.
    <bulleted list>
    ```
 
-3. Show the rendered body to the user. Ask: "File this now via `gh issue create`, or print only?"
+3. **Decomposition check** — before showing the rendered body, evaluate against three over-scoping signals (these mirror `tooling/check_issue_scope.py`, the server-side gate in `agent-intake.yml`):
 
-4. If they confirm filing, run:
+   - **Module count.** `Affected modules` lists more than 2 entries.
+   - **Goal track count.** First paragraph of `Goal` contains 3+ distinct verb phrases joined by `and` / `plus` / `also`.
+   - **Knowledge mandate without reference.** `Constraints` or `Scope` mentions knowledge-backing AND `ls reference/ 2>/dev/null | wc -l` reports ≤2 entries (just `.gitignore` + `README.md`).
+
+   If any signal trips, surface a one-line summary of each apparent track and offer three options:
+
+   - **A. Split into N issues**, sequentially. Loop Step 1-2 once per track; each gets its own focused `Affected modules` and single-track `Goal`.
+   - **B. File as one issue.** Prepend a `### Scope acknowledgment` section noting why the bundle is intentional, for post-mortem traceability.
+   - **C. Trim to one track.** Loop back to Step 1 with the user's chosen single track.
+
+   Default: surface — never silently file a flagged draft. After the user picks, continue to Step 4.
+
+   Why this exists: PR #28 took 17 regenerations in part because issue #26 bundled four tracks AND mandated knowledge backing on an empty reference. The server-side linter (`tooling/check_issue_scope.py`) hard-rejects the same patterns, but catching at draft time is cheaper for the user (no failed run to clean up) and friendlier (interactive split vs. blunt rejection).
+
+4. Show the rendered body to the user. Ask: "File this now via `gh issue create`, or print only?"
+
+5. If they confirm filing, run:
    ```bash
    gh issue create --title "[agent] <title>" --body-file - <<'EOF'
    <rendered body>
@@ -51,7 +67,7 @@ Goal: produce a complete issue body matching `.github/ISSUE_TEMPLATE/agent-task.
    ```
    Echo back the issue URL.
 
-5. Remind: a maintainer must apply the `agent:run` label to start the workflow. Filing alone only attaches the inert `agent:task` label.
+6. Remind: a maintainer must apply the `agent:run` label to start the workflow. Filing alone only attaches the inert `agent:task` label.
 
 ## Notes
 


### PR DESCRIPTION
Inserts a Step 3 in `.claude/skills/create-agent-task/SKILL.md` that, before showing the rendered body to the user, evaluates the draft against the same three over-scoping signals as the server-side linter (`tooling/check_issue_scope.py`, see paired PR #35):

- `Affected modules` lists more than 2 entries
- `Goal` first paragraph has 3+ tracks joined by `and`/`plus`/`also`
- Knowledge mandate while `reference/` is empty

If any trips, the skill surfaces the apparent tracks and offers three options:

- **A. Split into N issues** sequentially
- **B. File as one** with a `### Scope acknowledgment` section
- **C. Trim to one track** and loop back to Step 1

Belt-and-suspenders with the server-side linter: the skill catches over-scoping at draft time (cheaper, no failed CI run to clean up, friendlier interactive split); the linter catches what slips through (other authors, paste from old templates, manual `gh issue create` bypassing the skill).

Steps 3-5 in the original flow renumber to 4-6.

Plan + rationale: `work/ideas/2026-05-09_decomposition_skill.md` (gitignored).

The skill is conversational — no automated test. Verify by invoking `/create-agent-task` with a draft like PR #26's content (4 tracks across 3 modules with knowledge mandate); the new Step 3 should fire and offer the split.