### PR TITLE
Fix sanitization gate: word-boundary match on identifier prefixes

### DIFF
--- a/tooling/check_sanitization.py
+++ b/tooling/check_sanitization.py
@@ -87,10 +87,14 @@ PROPER_NOUN_LITERALS: List[Tuple[str, str]] = [
     ("mobjtype", "source-code identifier (thing-type enum)"),
     ("ammotype", "source-code identifier (ammo-type enum)"),
     ("weapontype", "source-code identifier (weapon-type enum)"),
-    # Source-code identifier prefixes — match anywhere in a token. These are
-    # the named, pre-known reference prefixes; keeping them explicit means
+    # Source-code identifier prefixes — match at a word boundary only. These
+    # are the named, pre-known reference prefixes; keeping them explicit means
     # `release-notes` mode (which drops the generic SCREAMING_SNAKE fallback)
     # still rejects e.g. `MT_PLAYER`, `MF_SPECIAL`, `SPR_STIM`, `MN_GAMEMSG`.
+    # Substring matching (the previous behaviour) fired on legitimate prose
+    # like `column_height` (containing `mn_`) — real source-code mentions
+    # always sit at a word boundary, so the boundary form preserves recall
+    # while dropping the false positives. See `build_compiled_patterns`.
     ("mt_", "source-code identifier prefix (thing-type macro)"),
     ("mf_", "source-code identifier prefix (mobj-flag macro)"),
     ("spr_", "source-code identifier prefix (sprite enum)"),
@@ -140,9 +144,17 @@ def build_compiled_patterns(
 ) -> List[Tuple[re.Pattern, str]]:
     compiled: List[Tuple[re.Pattern, str]] = []
     for literal, kind in PROPER_NOUN_LITERALS:
-        # Word-boundary-ish match: we use case-insensitive substring search.
-        # Wrapping in re.escape so that periods etc. are literal.
-        pattern = re.compile(re.escape(literal), re.IGNORECASE)
+        # Identifier *prefixes* (kind tagged "source-code identifier prefix")
+        # match only at a word boundary — substring match was over-eager and
+        # fired on legitimate prose like `column_height` (the substring `mn_`
+        # sits inside the word). Real source-code mentions of `MN_FOO` /
+        # `mn_bar` / etc. always begin at a word boundary, so this preserves
+        # recall while dropping false positives. Other literals (full names
+        # like `mobjtype`, cheat codes, lump names) keep substring match.
+        if kind.startswith("source-code identifier prefix"):
+            pattern = re.compile(r"\b" + re.escape(literal), re.IGNORECASE)
+        else:
+            pattern = re.compile(re.escape(literal), re.IGNORECASE)
         compiled.append((pattern, kind))
     for raw, kind in REGEX_PATTERNS:
         if drop_generic_fallback and kind == GENERIC_SCREAMING_SNAKE_KIND:


### PR DESCRIPTION
The sanitization gate's prefix literals (`mt_`, `mf_`, `spr_`, `mn_`) used plain substring match, which fired on legitimate prose containing those substrings mid-word — most recently `column_height`, `column_render_scale`, `column_angle` in `knowledge/raycaster_renderer.md` produced by the agent-intake run for #37, blocking otherwise valid Extractor output.

The fix: for entries tagged `source-code identifier prefix`, anchor with `\b` (word boundary). Real source-code mentions of `MN_FOO`, `mn_bar`, `MT_PLAYER`, `SPR_STIM` always sit at a word boundary, so recall on real leaks is preserved while compound-word false positives drop. Other literals (`mobjtype`, cheat codes like `iddqd`, lump names like `stbar`) keep substring match — those don't suffer from the same false-positive pressure.

Verified locally: `column_height` / `column_index` / `column_render_scale` / `column_angle` no longer trip the gate; `MN_GAMEMSG` / `mn_foo` / `MT_PLAYER` / `SPR_STIM` still do.

Unblocks #37.
