### PR TITLE
Retry commit→PR resolution in post-merge-snapshot for squash-merge races

### DIFF
--- a/.github/workflows/post-merge-snapshot.yml
+++ b/.github/workflows/post-merge-snapshot.yml
@@ -54,10 +54,29 @@ jobs:
         id: pr
         run: |
           set -e
-          PR_NUM=$(gh api "/repos/${{ github.repository }}/commits/${GITHUB_SHA}/pulls" \
-                   --jq '.[0].number // empty')
+          # GitHub's commits/<sha>/pulls endpoint can take several seconds
+          # to associate a freshly-squashed merge commit with its source
+          # PR. Observed on PR #40 (snapshot run #25630678899): workflow
+          # fired 3s after merge, the API returned [], the workflow logged
+          # "Direct push to main" and skipped — ten minutes later the same
+          # query returned the PR. Poll for up to ~30s before giving up.
+          # Legitimate direct pushes to main (no PR exists) still hit the
+          # warning path after the polling window.
+          PR_NUM=""
+          for attempt in 1 2 3 4 5; do
+            PR_NUM=$(gh api "/repos/${{ github.repository }}/commits/${GITHUB_SHA}/pulls" \
+                     --jq '.[0].number // empty')
+            if [ -n "$PR_NUM" ]; then
+              echo "Resolved PR #${PR_NUM} on attempt ${attempt}."
+              break
+            fi
+            if [ "$attempt" -lt 5 ]; then
+              echo "Attempt ${attempt}: no PR yet for ${GITHUB_SHA}; waiting 6s..."
+              sleep 6
+            fi
+          done
           if [ -z "$PR_NUM" ]; then
-            echo "::warning::Direct push to main (no PR found for ${GITHUB_SHA}). Snapshot not updated."
+            echo "::warning::Direct push to main (no PR found for ${GITHUB_SHA} after polling 30s). Snapshot not updated."
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi


### PR DESCRIPTION
On PR #40 (which fixed the raycaster fisheye correction), `post-merge-snapshot.yml` ran 3 seconds after the squash merge and exited with `##[warning]Direct push to main (no PR found for 80f7f64f...). Snapshot not updated.` Ten minutes later, querying `commits/80f7f64f/pulls` returned PR #40 normally — the GitHub API simply hadn't finished propagating the squash-merge commit→PR association at workflow start.

Effect: the `generated-snapshot` branch was left pointing at PR #39's regen artifact, even though PR #40's CI run had produced the corrected `raycaster.rs` with the explicit `cos(angle_offset)` multiplication. Future PRs that don't touch `specs/45_raycaster_renderer.md` (e.g. slice 5 of the renderer migration, which only regenerates `main`) would have inherited the broken Euclidean code from the stale baseline.

PR #40's artifact was already pushed to `generated-snapshot` manually outside this workflow (commit 69417bd on that branch — `SNAPSHOT.json` carries a `manual_backfill_reason` field documenting the path). This PR makes the workflow itself robust so the same race doesn't strand future regen-bearing merges.

Change: in the "Resolve source PR" step, poll `commits/<sha>/pulls` up to 5 times with 6-second backoff (~30 s worst-case wait) before declaring "direct push" and skipping. Legitimate direct pushes to main (no PR) still hit the same warning path after the polling window — only the noise floor for genuine squash-merge races moves down.

No spec/IR/knowledge changes. The workflow file is the only diff.