### PR TITLE
release.yml: match matrix bin to Coder-emitted worldsmith-game name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,17 +162,17 @@ jobs:
           - platform: linux-x86_64
             os: ubuntu-latest
             archive: tar.gz
-            bin: game
+            bin: worldsmith-game
             ext: ""
           - platform: macos-aarch64
             os: macos-latest
             archive: tar.gz
-            bin: game
+            bin: worldsmith-game
             ext: ""
           - platform: windows-x86_64
             os: windows-latest
             archive: zip
-            bin: game.exe
+            bin: worldsmith-game.exe
             ext: ".exe"
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45


### PR DESCRIPTION
The 2026.04 release run ([#25670337576](https://github.com/RuslanMingaliev/worldsmith/actions/runs/25670337576)) generated cleanly and built three platform binaries, but the Package step failed on all three platforms because the matrix `bin: game` expects a binary named `game` while the Coder-generated `Cargo.toml` in this run pinned the package and bin names to `worldsmith-game`. cargo produced `target/release/worldsmith-game(.exe)`; `cp .../game` returned no-such-file and the platform tarballs were never assembled.

The 2026.03 release happened to ship `[package].name = "game"` and the matrix matched by coincidence; nothing in `specs/` or `ir/contracts/` pins the Cargo package name today, so the Coder is free to pick a different name on every full regen and the matrix only matches one of them.

Switch the matrix to `worldsmith-game(.exe)` to match the current generated `Cargo.toml`. After merge, `gh run rerun --failed 25670337576` will reuse the existing `generation-2026.04` artifact (still inside the 14-day retention window) and re-run only the build jobs — no fresh LLM regen pass needed.

Out of scope: pinning the Cargo package name in `specs/80` or `ir/contracts/_shared.yaml` so future regens are deterministic. Tracked separately.