### PR TITLE
specs/80: pin generated Cargo.toml package/bin name to worldsmith-game

### DIFF
--- a/specs/80_generation_rules.md
+++ b/specs/80_generation_rules.md
@@ -137,6 +137,16 @@ fn update_enemy(enemy: &mut Enemy) {
 - Do NOT use Entity-Component-System (ECS) architecture
 - Keep data structures straightforward and explicit
 
+### Cargo Manifest
+
+The generated `Cargo.toml` MUST pin these values verbatim so the release pipeline (`release.yml` matrix `bin:` entry) can locate the built binary at a stable path. Coder-side discretion in package naming has historically broken `release.yml`'s `Package binary archive` step (2026.04 release run #25670337576: Coder produced `[package].name = "worldsmith-game"`; release.yml matrix expected `bin: game`, the previous 2026.03 release shipped with).
+
+- `[package].name = "worldsmith-game"`
+- `[[bin]].name = "worldsmith-game"`
+- `[[bin]].path = "src/main.rs"`
+
+cargo will then build the binary as `target/release/worldsmith-game` on Unix and `target/release/worldsmith-game.exe` on Windows, matching `.github/workflows/release.yml`'s matrix.
+
 ### Dependencies
 
 - Minimize external dependencies


### PR DESCRIPTION
The 2026.04 release run failed twice on the Package step because the generated `Cargo.toml` name is currently Coder-discretion — nothing in `specs/` or `ir/contracts/` pins it. 2026.03 happened to ship `[package].name = "game"`; the 2026.04 regen produced `"worldsmith-game"`. The `release.yml` matrix's `bin:` field matches only one of the two, so every release run rolls the dice on whether the Package step succeeds.

PR #57 already moved the `release.yml` matrix to expect `worldsmith-game` (matching the current generated state); this PR pins the spec so future regens emit the same name deterministically. Choice of `worldsmith-game` over `game` matches:

- The current generated `Cargo.toml`, so the next regen is a no-op on this dimension.
- The released tarball naming convention (`worldsmith-game-VERSION-PLATFORM.tar.gz`).
- The src-zip naming convention (`worldsmith-game-VERSION-src.zip`).

After this lands, a fresh `release.yml` workflow_dispatch for 2026.04 will deterministically produce a Cargo.toml matching the matrix; the failing Package step will succeed and the release job will publish the draft.