### PR TITLE
tooling/agents: distinguish release vs partial regen; make release notes content-driven

### DIFF
--- a/tooling/agents/coder.md
+++ b/tooling/agents/coder.md
@@ -130,6 +130,65 @@ When you see such a scope override:
 - Unit tests inside the target module file are in scope; integration tests
   outside `generated/game/src/` are not your responsibility.
 
+## Release regeneration mode
+
+The release workflow (`.github/workflows/release.yml`) runs Coder with
+`--mode release` and **no** `--target-modules` flag — no `Scope override`
+listing specific targets in the prompt. The semantics differ from partial
+regen in five hard ways; mis-applying partial-mode habits to release-mode
+runs has been the failure mode of every release regen since 2026.02.
+
+- **`generated/game/src/` is empty at start.** The release workflow does NOT
+  fetch `generated-snapshot`, does NOT unpack the previous release's
+  `worldsmith-game-*-src.zip`, and does NOT have an orchestrator-side
+  snapshot/revert guard. `generated/` is gitignored and the fresh checkout
+  brings nothing under it. You generate every module from scratch using
+  specs + IR only.
+- **There is no baseline to "carry from".** Do NOT use the phrase "carried
+  from prior session", "carry-forward", or similar in `coder_report.md`.
+  Every module in `### Modules generated` is a fresh emission — if it ends
+  up byte-identical to the previous release's tree, that is a property of
+  determinism, not of carrying. The 2026-05-11 release regen used
+  "carried from prior session" framing for 10 of 14 modules; PostMortem
+  built a false drift narrative on top of that framing. The bytes were
+  fresh; only the report wording was wrong.
+- **This regen becomes the next baseline for every subsequent PR-mode
+  run.** `post-merge-snapshot.yml` force-pushes this release's
+  `generated/` to the `generated-snapshot` branch on merge. Whatever
+  Coder ships here — API surface, test coverage, contract fidelity —
+  baselines into the snapshot and is inherited by every PR regen until
+  the next release. A 16-test coverage drop in a release-mode emission
+  is not "this release loses 16 tests" — it is "every future PR-mode
+  regen builds on a 16-tests-poorer baseline". Treat the release-mode
+  quality bar as strictly higher than partial-mode for this reason,
+  not lower.
+- **Test-count parity check in release mode compares against the prior
+  release tag, not the snapshot.** The snapshot reflects the most
+  recent PR-mode emission, which may itself carry accumulated drift
+  inherited across the release window. The release-to-release diff is
+  the authoritative one for the user-facing question "did test coverage
+  regress in this release?". Mechanical check, per module:
+  ```
+  # Prior release tag comes via the `## Scope override` block as `previous_tag`.
+  PRE=$(git show <previous_tag>:generated/game/src/<module>.rs 2>/dev/null \
+        | grep -c '#\[test\]' || echo 0)
+  POST=$(grep -c '#\[test\]' generated/game/src/<module>.rs)
+  ```
+  Report any `POST < PRE` module in `### Build validation run` under a
+  `Coverage delta vs <previous_tag>:` line so Reconciler sees it without
+  re-running the grep. Disclosure is mandatory even if you judge the
+  drop justified — Reconciler decides whether to escalate.
+- **Contract simplifications are forbidden in release mode without an
+  explicit disclosure.** In partial-mode you may simplify an enum
+  variant's payload (e.g. `Kill(String) → Kill`) when no live consumer
+  reads the payload, provided you list it in
+  `### API Surface compromises and contract simplifications`. In
+  release-mode the same simplification permanently narrows the
+  contract for every future regen — disclose it AND open
+  `artifacts/blocker.md` describing the contract delta. The PostMortem
+  has to surface this to the maintainer; without `blocker.md`, the
+  simplification gets baselined silently.
+
 ## Quality Checklist
 
 Before submitting:

--- a/tooling/agents/postmortem.md
+++ b/tooling/agents/postmortem.md
@@ -60,6 +60,13 @@ Append a **`## PostMortem Section`** at the end of the run journal, *after* the 
 
 Categorise every recommendation:
 
+**Mode-aware recommendation framing.** Before drafting, identify the run mode from the orchestrator invocation: release mode = `--mode release` and no `--target-modules`; PR / partial mode = `--target-modules <list>` present in the invocation (visible in `artifacts/usage.jsonl` or the orchestrator's run-command echo). The mode shapes which follow-ups are mechanically possible:
+
+- **Release mode.** "Follow-up Coder pass with `--target-modules X,Y` to restore the dropped tests" is **not a valid recommendation** — `release.yml` does not pass `--target-modules`, there is no partial-regen mechanism in the release pipeline, and prescribing one creates a false sense of cheap recoverability. The three follow-up shapes that ARE valid in release mode: (1) re-run `release.yml` for the same `version` input — concurrency group rewrites the existing draft, but it is a fresh full regen with a different random seed and no guarantee of restoring what dropped; (2) land a structural-fix PR first (e.g. pin the missing tests as `required_tests:` in `ir/contracts/<module>.yaml`, or split a contract enum that was simplified) and then re-run `release.yml` — slower but deterministic; (3) publish the draft as-is with an explicit caveat in release notes that names what regressed. Pick one and name which.
+- **PR / partial mode.** A `--target-modules` Coder pass IS valid — that is the mechanism the workflow already uses. Recommendations may prescribe it freely.
+
+The 2026-05-11 release postmortem (Worldsmith 2026.04) recommended "the next action is a follow-up Coder pass" without qualifying the mode. The release operator read this as "a cheap fix exists" and the recommendation propagated unfounded confidence. Mode-tagging every actionable recommendation closes that ambiguity.
+
 #### Agent-prompt changes
 
 For each agent-prompt change, **apply the edit directly** to

--- a/tooling/agents/reconciler.md
+++ b/tooling/agents/reconciler.md
@@ -66,6 +66,19 @@ Any module where `POST < PRE` is a **coverage regression** — log under `### Dr
 
 Bare `Tests passing: N / N` in the report is **insufficient** when N decreased between regens. The 2026-05-08 release regen on commit `9ec001f` shipped 35 tests vs. 64 in the prior commit `b3a5237` — net loss of ~27 unit tests across `autopilot.rs` (-9), `game_loop.rs` (-5), `renderer.rs` (-4), and others. Reconciler's report read "Tests passing: 35 / 35" without flagging the drop; PostMortem propagated the same framing. The coverage hole would have baselined into `generated-snapshot` on merge, making restoration progressively harder for future PRs.
 
+**Release-mode addendum.** In release mode (orchestrator invoked with `--mode release` and no `--target-modules`), run the same grep against the **prior release tag** in addition to `generated-snapshot`:
+
+```
+# previous_tag is provided by the orchestrator's `## Scope override` block.
+PRE_REL=$(git show <previous_tag>:generated/game/src/<module>.rs 2>/dev/null \
+          | grep -c '#\[test\]' || echo 0)
+PRE_SNAP=$(git show origin/generated-snapshot:src/<module>.rs 2>/dev/null \
+           | grep -c '#\[test\]' || echo 0)
+POST=$(grep -c '#\[test\]' generated/game/src/<module>.rs)
+```
+
+Both diffs matter and the severity is the same release-blocker tier: `POST < PRE_REL` is the user-facing claim ("did this release regress coverage vs the last published release?") and goes verbatim into the Reconciler report so release_editor can reflect it in release notes; `POST < PRE_SNAP` catches drift accumulated between releases that should not propagate to the next snapshot. Log both as separate entries under `### Drift found` so PostMortem can distinguish "release-window drift" from "this-regen drift". The 2026-05-11 release regen shipped 61 tests vs. 77 in `generated-snapshot` (release-blocker D3) but the prior-release diff was never computed, so the user-facing line in release notes silently claimed "gameplay unchanged" — see release_editor.md § Inputs you should read.
+
 In manual (non-CI) mode, where `origin/generated-snapshot` may not be fetched, fall back to `git fetch origin generated-snapshot --depth=1` before the grep. If the ref still does not exist (first-run / fork), skip the check with a note in the report rather than failing — the floor is the workflow-fetched baseline; without it there is no prior state to compare against.
 
 Only proceed to Step 1 once warnings have been triaged into "spec drift" / "cfg-test-only / needs gate" / "expected wave-cascade noise" / "orphan-file" / "coverage-regression" buckets and recorded in the report.

--- a/tooling/agents/release_editor.md
+++ b/tooling/agents/release_editor.md
@@ -10,9 +10,13 @@ You are given:
 
 - `artifacts/postmortem.md` — the agent pipeline's post-mortem of THIS release's regen pass. Internal-leaning, but a useful source for "what was hard / what to flag".
 - `artifacts/manifest.json` — module count, LoC, test summary, rustc version, generation date.
-- `git log --merges --pretty='format:%H %s' <prev_tag>..HEAD` — merge commits between the previous tag and HEAD. Each merge usually corresponds to a PR.
-- For each merge line `Merge pull request #N from ...`, run `gh pr view N --json title,body,number,labels,closingIssuesReferences` to get the PR title, body, and any linked issues. The body usually contains the intent (Goal / Scope / etc.).
-- Optionally `git diff <prev_tag>..HEAD -- specs/` to verify a PR's claim against spec changes.
+
+**Walk the content diff BEFORE the PR list. Treat the diff as ground truth and the PR list as supporting evidence; not the other way around.** Run all three:
+
+- `git diff --stat <prev_tag>..HEAD -- specs/ knowledge/ ir/` — content footprint of the release. **Any new file under `specs/` or `knowledge/`, and any single-file change above ~50 lines, is presumed user-facing and MUST be reflected in the release notes regardless of which PR introduced it.** If a 600-line `specs/45_<area>.md` lands and you cannot find a matching bullet in your draft, the draft is wrong — go back to the diff.
+- `git log --merges --pretty='format:%H %s' <prev_tag>..HEAD` — merge commits between the previous tag and HEAD. Each merge usually corresponds to a PR. Use the list to attribute the diff above to specific PRs, NOT to decide what to include — inclusion is driven by the diff.
+- For each merge line, run `gh pr view N --json title,body,number,labels,closingIssuesReferences`. **You may not classify a PR as housekeeping based on its title alone — every PR in the range gets its body read.** The 2026-05-11 release regen (Worldsmith 2026.04) shipped notes that omitted a 627-line new `specs/45_raycaster_renderer.md` plus four new `knowledge/raycaster_*.md` files because the eight PRs that introduced them had opaque agent-intake titles and were classified as housekeeping without their bodies being opened.
+- For PR titles matching the pattern `agent: refresh from issue #<N>`: these are automatically generated for slices of agent-task–driven work (see `.github/workflows/agent-intake.yml`). The title carries no signal about content — the scope lives in the linked issue body. ALWAYS resolve `closingIssuesReferences` and run `gh issue view <N> --json title,body,labels` for each. The issue body has Goal / Scope / Acceptance criteria that describe the actual user-facing change.
 
 The previous tag comes via the `## Scope override` block at the top of this prompt (key `previous_tag`). If missing, use `git describe --tags --abbrev=0 HEAD^` as a fallback.
 
@@ -31,13 +35,27 @@ Answer: "what happened in this release, and why does the reader care". Plainspok
 
 ### `artifacts/release_whatsnew.md`
 
-A bulleted "What's new" list. One bullet per merged PR that ships user-facing or process-facing change. **Drop housekeeping/nit PRs that don't move gameplay, generation pipeline, or release process.** Format each bullet with a clickable PR link:
+A bulleted "What's new" list. One bullet per merged PR (or per grouped theme — see below) that ships user-facing or process-facing change. Format each bullet with a clickable PR link:
 
 ```
 - **[#NN](https://github.com/RuslanMingaliev/worldsmith/pull/NN) — Bold headline (4–8 words)** — One or two sentences expanding into concrete impact. Cite spec/section if applicable.
 ```
 
-Substitute the actual PR number into both the link text and the URL. Order bullets by impact, not chronology. If 6+ bullets remain after dropping nits, group into thematic sub-sections (`### Gameplay`, `### Pipeline`, `### Release process`).
+Substitute the actual PR number into both the link text and the URL. Order bullets by impact, not chronology. If 6+ bullets remain after grouping, organise into thematic sub-sections (`### Gameplay`, `### Renderer`, `### Pipeline`, `### Specs`, `### Release process`).
+
+**Dropping a PR ("housekeeping/nit") is a deliberate decision, not a default.** A PR is a drop candidate ONLY if all three hold:
+- Its body reads as pure infrastructure (CI tweak, dependency bump, formatting) AND
+- Its diff against `<prev_tag>..HEAD` touches NO `specs/`, `knowledge/`, or `ir/` files AND
+- Its body and linked-issue body contain no Goal / Scope / Acceptance-criteria sections.
+If any of the three fails, the PR is in. When in doubt, include it — the false-positive cost of one extra line in release notes is far smaller than the false-negative cost of hiding the release's headline (see the 2026.04 incident in "Inputs you should read").
+
+**Grouping rule for multi-slice agent-task series.** When ≥2 PRs in the range have titles of the form `agent: refresh from issue #N` AND their linked issues cross-reference each other (shared ADR, shared epic, sequential slice numbers, or the issue body explicitly says "slice K of M"), emit ONE thematic section bullet for the series rather than N separate bullets — but the bullet must list every contributing PR number and cite the umbrella issue / ADR. Example for a renderer migration shipped as six slices:
+
+```
+### Renderer
+
+- **First-person renderer (slices 1–6: [#39](https://github.com/RuslanMingaliev/worldsmith/pull/39), [#40](https://github.com/RuslanMingaliev/worldsmith/pull/40), [#47](https://github.com/RuslanMingaliev/worldsmith/pull/47), [#49](https://github.com/RuslanMingaliev/worldsmith/pull/49), [#50](https://github.com/RuslanMingaliev/worldsmith/pull/50), [#52](https://github.com/RuslanMingaliev/worldsmith/pull/52), [#53](https://github.com/RuslanMingaliev/worldsmith/pull/53), [#54](https://github.com/RuslanMingaliev/worldsmith/pull/54))** — Migration from top-down to first-person 3D rendering, specced in the new `specs/45_<area>.md` (627 lines) and grounded in four new `knowledge/<area>_*.md` files. Each slice landed an independent piece (geometry, vertical projection, sprites, HUD, effects, integration); see the umbrella issue for the full ADR.
+```
 
 ## Constraints
 
@@ -63,3 +81,4 @@ Substitute the actual PR number into both the link text and the URL. Order bulle
 - If git log between tags is empty: write a short hero saying "Patch release: <list of fixes>" and an empty whatsnew. Don't fabricate.
 - If `gh pr view` fails on a PR: include the PR number with `[title unavailable — see commit log]` rather than skipping silently.
 - If `artifacts/postmortem.md` is absent: skip its inputs; rely on PR bodies + spec diff alone. Don't fail the run.
+- **If after drafting whatsnew you cannot point every new file under `specs/` and `knowledge/` (from the mandatory `git diff --stat` walk) to at least one bullet that mentions it, the draft is incomplete. Loop: re-read the unattributed file, find the PRs that introduced it via `git log <prev_tag>..HEAD -- <path>`, open those PR bodies, write the missing bullet.** Do not ship a draft that elides new spec/knowledge content — that is the 2026.04 incident verbatim.


### PR DESCRIPTION
Four agent-prompt fixes informed by the 2026.04 release post-mortem. Touches only `tooling/agents/*.md` — source-of-truth path, so `pr.yml` will run a full regen on this PR.

**Context.** Worldsmith 2026.04's draft release notes silently omitted the release's headline content (a 627-line new spec plus four new knowledge files describing the first-person renderer migration), and the post-mortem itself recommended a "follow-up Coder pass" that does not mechanically exist in release mode. Root causes traced to four prompts:

`release_editor.md`
- The `git diff` walk against `specs/ knowledge/ ir/` was "optional"; promoting it to mandatory and making the diff the primary input (PR list becomes attribution, not inclusion).
- Title-based housekeeping drop misclassified the eight `agent: refresh from issue #N` slice PRs that introduced the renderer migration. Reframed drop as a deliberate three-condition test (body is pure infra AND no specs/knowledge/IR touched AND no Goal/Scope/Acceptance in body or linked issue). When in doubt, include.
- Added a grouping rule for multi-slice agent-task series: one thematic section with all contributing PR numbers, not N separate bullets.
- New failure mode at file foot: if any new spec/knowledge file from the diff is not pointed to by a draft bullet, the draft is incomplete — loop.

`coder.md`
- New "Release regeneration mode" section parallel to the existing "Partial regeneration mode".
- Codifies five hard differences: empty baseline at start; "carried from prior session" framing forbidden; this regen baselines into `generated-snapshot` on merge so quality bar is strictly higher than partial-mode (not lower); test-count parity check compares against the prior release tag rather than the snapshot; contract simplifications require an explicit `artifacts/blocker.md` note.

`reconciler.md`
- Step 0 test-count parity check gets a release-mode addendum: run the grep against both `generated-snapshot` and the prior release tag, log both deltas under Drift found so PostMortem can separate release-window drift from this-regen drift, and so `release_editor` can reflect the release-to-release delta in release notes.

`postmortem.md`
- "Recommendations" section gets a mode-aware framing block. Release-mode postmortems may NOT recommend "follow-up Coder pass with --target-modules" — `release.yml` does not pass `--target-modules` and the partial-regen mechanism does not exist there. The three valid release-mode follow-ups are enumerated (re-run release with same version, structural-fix PR first, publish with caveat).

The 2026.04 post-mortem and the resulting "pipeline pass, gameplay unchanged" framing in the draft release notes is the test case for every change here.