### PR TITLE
release: lock in lean release notes template (no PR enumeration, surface models/cost)

### DIFF
--- a/.github/release-notes.template.md
+++ b/.github/release-notes.template.md
@@ -2,9 +2,17 @@
 
 ![Worldsmith {{VERSION}} gameplay](https://github.com/RuslanMingaliev/worldsmith/releases/download/{{VERSION}}/worldsmith-{{VERSION}}-gameplay.gif)
 
-## What's new since {{PREV_VERSION}}
+## How it was generated
 
-{{WHATSNEW_PROSE}}
+End-to-end on {{GENERATED_AT}} through the multi-agent pipeline: Architect drafts the per-module contracts, Coder writes the Rust, Reconciler reconciles code against specs, PostMortem audits the run, Release Editor authors these notes.
+
+{{TOKENS_TABLE}}
+
+Plus {{CACHE_READ_TOTAL}} cache reads / {{CACHE_CREATION_TOTAL}} cache creation — the inlined frozen-context prefix (specs + IR + shared contract) is shared across phases, so the second Architect / Coder / Reconciler call onward serves the prefix from cache instead of re-billing it.
+
+**Output: {{MODULE_COUNT}} modules, ~{{LOC}} lines of Rust.** Built with `{{RUSTC_VERSION}}`, edition 2024, single runtime dependency: `minifb` (window + framebuffer). {{TEST_SUMMARY}}.
+
+{{BUILD_HEALTH_NOTE}}
 
 ## Try it
 
@@ -27,22 +35,4 @@ This is a spec-driven game. The Rust code is regenerable; the **specs** are what
 - [`knowledge/`](https://github.com/RuslanMingaliev/worldsmith/tree/{{VERSION}}/knowledge) — sanitized findings extracted from reference material.
 - [`tooling/agents/`](https://github.com/RuslanMingaliev/worldsmith/tree/{{VERSION}}/tooling/agents) — the prompts that generated this code.
 - [`worldsmith-{{VERSION}}-postmortem.md`](https://github.com/RuslanMingaliev/worldsmith/releases/download/{{VERSION}}/worldsmith-{{VERSION}}-postmortem.md) — full agent-pipeline post-mortem: what worked, what hurt, what to fix next time.
-
-## Stats
-
-**{{MODULE_COUNT}} modules** · ~{{LOC}} lines of Rust · {{TEST_SUMMARY}} · `{{RUSTC_VERSION}}`, edition 2024 · single dependency: `minifb` (window + framebuffer).
-
-<details>
-<summary>Generation report (token usage, post-mortem highlights)</summary>
-
-Generated end-to-end from `specs/` on {{GENERATED_AT}} via the multi-agent pipeline (Architect contracts pass → Coder → Reconciler → PostMortem → Release Editor).
-
-### Token usage
-
-{{TOKENS_TABLE}}
-
-### Post-mortem summary
-
-{{POSTMORTEM_SUMMARY}}
-
-</details>
+- [Full PR-by-PR diff vs `{{PREV_VERSION}}`](https://github.com/RuslanMingaliev/worldsmith/compare/{{PREV_VERSION}}...{{VERSION}}).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -302,7 +302,7 @@ jobs:
           mkdir -p release
           xvfb-run -a tooling/record_autopilot.sh tests/level/scavenge_run.yaml release/demo.gif
 
-      - name: Package src zip + demo GIF
+      - name: Package src zip + demo GIF + postmortem
         env:
           VERSION: ${{ inputs.version }}
         run: |
@@ -311,6 +311,16 @@ jobs:
           mv "artifacts/worldsmith-game-${VERSION}-src.zip" \
              "assets/worldsmith-game-${VERSION}-src.zip"
           cp release/demo.gif "assets/worldsmith-${VERSION}-gameplay.gif"
+          # The release-notes template's Read-it section links to
+          # worldsmith-<VERSION>-postmortem.md as a release asset.
+          # PostMortem agent always writes artifacts/postmortem.md per
+          # tooling/agents/postmortem.md § CI output target; copy it
+          # into assets/ so the link resolves at /releases/download/<tag>/...
+          if [ -f artifacts/postmortem.md ]; then
+            cp artifacts/postmortem.md "assets/worldsmith-${VERSION}-postmortem.md"
+          else
+            echo "::warning::artifacts/postmortem.md missing; postmortem asset will not ship."
+          fi
 
       - name: Build manifest
         run: |
@@ -384,11 +394,9 @@ jobs:
             --version "$VERSION" \
             --prev-version "${PREV_TAG:-unknown}" \
             --usage-jsonl artifacts/usage.jsonl \
-            --postmortem artifacts/postmortem.md \
             --manifest artifacts/manifest.json \
             --release-hero artifacts/release_hero.md \
-            --release-whatsnew artifacts/release_whatsnew.md \
-            --assets-dir assets \
+            --release-buildhealth artifacts/release_buildhealth.md \
             --out artifacts/release-notes.md
 
       - name: Upload release assets bundle

--- a/tooling/agents/release_editor.md
+++ b/tooling/agents/release_editor.md
@@ -13,7 +13,7 @@ You are given:
 
 **Walk the content diff BEFORE the PR list. Treat the diff as ground truth and the PR list as supporting evidence; not the other way around.** Run all three:
 
-- `git diff --stat <prev_tag>..HEAD -- specs/ knowledge/ ir/` — content footprint of the release. **Any new file under `specs/` or `knowledge/`, and any single-file change above ~50 lines, is presumed user-facing and MUST be reflected in the release notes regardless of which PR introduced it.** If a 600-line `specs/45_<area>.md` lands and you cannot find a matching bullet in your draft, the draft is wrong — go back to the diff.
+- `git diff --stat <prev_tag>..HEAD -- specs/ knowledge/ ir/` — content footprint of the release. **Any new file under `specs/` or `knowledge/`, and any single-file change above ~50 lines, is presumed user-facing and MUST be reflected in the hero regardless of which PR introduced it.** If a 600-line `specs/45_<area>.md` lands and you cannot find a sentence in your hero that names it, the hero is wrong — go back to the diff.
 - `git log --merges --pretty='format:%H %s' <prev_tag>..HEAD` — merge commits between the previous tag and HEAD. Each merge usually corresponds to a PR. Use the list to attribute the diff above to specific PRs, NOT to decide what to include — inclusion is driven by the diff.
 - For each merge line, run `gh pr view N --json title,body,number,labels,closingIssuesReferences`. **You may not classify a PR as housekeeping based on its title alone — every PR in the range gets its body read.** The 2026-05-11 release regen (Worldsmith 2026.04) shipped notes that omitted a 627-line new `specs/45_raycaster_renderer.md` plus four new `knowledge/raycaster_*.md` files because the eight PRs that introduced them had opaque agent-intake titles and were classified as housekeeping without their bodies being opened.
 - For PR titles matching the pattern `agent: refresh from issue #<N>`: these are automatically generated for slices of agent-task–driven work (see `.github/workflows/agent-intake.yml`). The title carries no signal about content — the scope lives in the linked issue body. ALWAYS resolve `closingIssuesReferences` and run `gh issue view <N> --json title,body,labels` for each. The issue body has Goal / Scope / Acceptance criteria that describe the actual user-facing change.
@@ -26,36 +26,31 @@ Exactly two files in `artifacts/`:
 
 ### `artifacts/release_hero.md`
 
-The top-of-page elevator. Plain markdown. Pick the form that fits the release content:
+The top-of-page elevator. **3–5 short paragraphs of narrative prose** that answer "what happened in this release, and why does the reader care".
 
-- **1–3 short paragraphs** if the release has one or two narrative threads.
-- **A short bulleted list (≤5 items)** if the release has multiple parallel drops with no single thread.
+Lead with the substance, not a changelog. The hero is the entire user-facing description of the release — **the template no longer carries a `## What's new` section with PR-by-PR bullets**. The compare view linked in "Read it" handles audit-trail discovery; the hero handles the *story*. You may cite a few PR numbers parenthetically when the PR is itself the headline ("the renderer migrated across six slices — [#39](https://...), [#40](https://...), ..."), but do not enumerate the release.
 
-Answer: "what happened in this release, and why does the reader care". Plainspoken indie-developer tone. No marketing buzzwords ("revolutionary", "leveraging", "powered by AI"). Cite spec sections when you make a feature claim (`spec/15`, `spec/50`) so readers can drill in. Do not start with the version number — the version is already in the title.
+What to lead with, in priority order:
 
-### `artifacts/release_whatsnew.md`
+1. **Gameplay-visible changes** the user notices on first launch (renderer, controls, AI, level design).
+2. **Spec-level structural changes** (new `specs/<n>_<area>.md`, new `knowledge/<area>_*.md` files — these are the project's actual artifacts and merit a paragraph when introduced).
+3. **Pipeline / agent / release-process changes** that meaningfully change how the next release is shipped (one sentence is usually enough; the post-mortem asset carries the detail).
 
-A bulleted "What's new" list. One bullet per merged PR (or per grouped theme — see below) that ships user-facing or process-facing change. Format each bullet with a clickable PR link:
+Plainspoken indie-developer tone. No marketing buzzwords ("revolutionary", "leveraging", "powered by AI"). Cite spec sections inline when you make a feature claim (`spec/45`, `spec/30`) so readers can drill in. Do not start with the version number — the version is already in the title.
 
-```
-- **[#NN](https://github.com/RuslanMingaliev/worldsmith/pull/NN) — Bold headline (4–8 words)** — One or two sentences expanding into concrete impact. Cite spec/section if applicable.
-```
+Walk the inputs in this order: (1) the mandatory `git diff --stat <prev_tag>..HEAD -- specs/ knowledge/ ir/` to ground every claim in a real content delta; (2) per-PR bodies to attribute the deltas to specific landing PRs (you may cite their numbers in prose but do not enumerate them); (3) the post-mortem for one-sentence acknowledgement of any rough edges. If the diff shows new files in `specs/` or `knowledge/` that you cannot fit into the hero, the hero is mis-prioritised — drop a pipeline paragraph rather than a content paragraph.
 
-Substitute the actual PR number into both the link text and the URL. Order bullets by impact, not chronology. If 6+ bullets remain after grouping, organise into thematic sub-sections (`### Gameplay`, `### Renderer`, `### Pipeline`, `### Specs`, `### Release process`).
+### `artifacts/release_buildhealth.md`
 
-**Dropping a PR ("housekeeping/nit") is a deliberate decision, not a default.** A PR is a drop candidate ONLY if all three hold:
-- Its body reads as pure infrastructure (CI tweak, dependency bump, formatting) AND
-- Its diff against `<prev_tag>..HEAD` touches NO `specs/`, `knowledge/`, or `ir/` files AND
-- Its body and linked-issue body contain no Goal / Scope / Acceptance-criteria sections.
-If any of the three fails, the PR is in. When in doubt, include it — the false-positive cost of one extra line in release notes is far smaller than the false-negative cost of hiding the release's headline (see the 2026.04 incident in "Inputs you should read").
+A **single paragraph** flagging anything Reconciler escalated that a publish-time human should know before flipping the draft to public — most commonly a test-coverage regression vs `origin/generated-snapshot` (Reconciler's Drift D-tier "release-blocker") or a contract-shape simplification that changes what the binary does.
 
-**Grouping rule for multi-slice agent-task series.** When ≥2 PRs in the range have titles of the form `agent: refresh from issue #N` AND their linked issues cross-reference each other (shared ADR, shared epic, sequential slice numbers, or the issue body explicitly says "slice K of M"), emit ONE thematic section bullet for the series rather than N separate bullets — but the bullet must list every contributing PR number and cite the umbrella issue / ADR. Example for a renderer migration shipped as six slices:
+If Reconciler's report has no Drift-flagged release-blockers, emit an **empty file** (literally zero bytes). The template renders `{{BUILD_HEALTH_NOTE}}` as empty in that case and the publish reads clean. Do NOT pad the file with "no regressions to flag" or similar — silence is the success signal.
 
-```
-### Renderer
+When you do emit a paragraph: name the magnitude (number of tests dropped, modules affected), the root cause in one phrase, and the location of the structural fix (PR number if landed, ADR draft if not). Example for a coverage drop:
 
-- **First-person renderer (slices 1–6: [#39](https://github.com/RuslanMingaliev/worldsmith/pull/39), [#40](https://github.com/RuslanMingaliev/worldsmith/pull/40), [#47](https://github.com/RuslanMingaliev/worldsmith/pull/47), [#49](https://github.com/RuslanMingaliev/worldsmith/pull/49), [#50](https://github.com/RuslanMingaliev/worldsmith/pull/50), [#52](https://github.com/RuslanMingaliev/worldsmith/pull/52), [#53](https://github.com/RuslanMingaliev/worldsmith/pull/53), [#54](https://github.com/RuslanMingaliev/worldsmith/pull/54))** — Migration from top-down to first-person 3D rendering, specced in the new `specs/45_<area>.md` (627 lines) and grounded in four new `knowledge/<area>_*.md` files. Each slice landed an independent piece (geometry, vertical projection, sprites, HUD, effects, integration); see the umbrella issue for the full ADR.
-```
+> **Known coverage regression.** Reconciler flagged a net loss of 19 unit tests against the most recent PR-mode baseline (`origin/generated-snapshot`): `level_generator` −8, `raycaster` −6, `autopilot` −4, plus −1 elsewhere. The dropped tests exercise symbols whose public signatures and runtime behavior still ship correctly — this is generation variance, not a functional break. Root cause: the Coder phase's own test-count parity check was looking at the prior release tag, which carries no `generated/` tree in this repo. Surgical fix is in PR #64; next release will either self-restore the tests or disclose the drop explicitly. Full details in the post-mortem asset.
+
+Read `artifacts/reconciler_report.md` § Drift found and § Test-count parity check to source numbers. Cross-check with `artifacts/postmortem.md` § What hurt for the root-cause framing. Do not invent numbers — every figure in the paragraph must trace to one of those two files.
 
 ## Constraints
 
@@ -71,15 +66,14 @@ If any of the three fails, the PR is in. When in doubt, include it — the false
 
 **Bad:** "Worldsmith 2026.03 leverages cutting-edge multi-agent generation to deliver groundbreaking gameplay enhancements."
 
-**Good:** "This release introduces purpose-built demo levels — a small abstraction (`spec/15`) that lets each gameplay behavior have its own minimal stage. The PR-preview GIF now records on `local_chase_obstacle`, where the enemy navigates around a wall to engage the player."
+**Good (opening paragraph):** "The 2026.04 release ships two big additions and a quieter wave of pipeline hardening underneath. Across six slices, the rendering pipeline migrated from a 2D top-down view to a column-based first-person raycaster (`spec/45`), specced from the reference engine's projection model and grounded in four new `knowledge/raycaster_*.md` files. The raycaster is now the default — `cargo run` opens in first-person; the top-down view stays in the codebase as a debug-only alternate mode (`--render-mode=topdown`) because it remains the fastest way to see at a glance what the bot and the enemies are actually doing on the map."
 
-**Bad bullet:** "- **#15 — release: swap PR-preview demo to local_chase_obstacle scenario** — This PR swaps the demo."
-
-**Good bullet:** "- **[#15](https://github.com/RuslanMingaliev/worldsmith/pull/15) — Demo records on the obstacle scenario** — PR-preview and release demo GIFs now use `tests/level/local_chase_obstacle.yaml`, demonstrating the new level generator (`spec/15`) end-to-end. The first 4 seconds of the GIF visibly show the enemy navigating around the wall."
+The "good" example is concrete (names the new spec/knowledge artifacts, the user-visible default change, and why a debug fallback exists) and zero PR numbers in the first paragraph — they belong inline only when a PR is itself the unit being discussed.
 
 ## Failure modes
 
-- If git log between tags is empty: write a short hero saying "Patch release: <list of fixes>" and an empty whatsnew. Don't fabricate.
-- If `gh pr view` fails on a PR: include the PR number with `[title unavailable — see commit log]` rather than skipping silently.
+- If git log between tags is empty: write a short hero saying "Patch release: <list of fixes>" and emit empty `release_buildhealth.md`. Don't fabricate.
+- If `gh pr view` fails on a PR: skip that PR with a note in the hero only if its content was load-bearing; for non-load-bearing ones (housekeeping), drop silently — the compare-view link covers audit.
 - If `artifacts/postmortem.md` is absent: skip its inputs; rely on PR bodies + spec diff alone. Don't fail the run.
-- **If after drafting whatsnew you cannot point every new file under `specs/` and `knowledge/` (from the mandatory `git diff --stat` walk) to at least one bullet that mentions it, the draft is incomplete. Loop: re-read the unattributed file, find the PRs that introduced it via `git log <prev_tag>..HEAD -- <path>`, open those PR bodies, write the missing bullet.** Do not ship a draft that elides new spec/knowledge content — that is the 2026.04 incident verbatim.
+- **If after drafting `release_hero.md` you cannot point every new file under `specs/` and `knowledge/` (from the mandatory `git diff --stat` walk) to at least one sentence that mentions it, the hero is incomplete. Loop: re-read the unattributed file, find the PRs that introduced it via `git log <prev_tag>..HEAD -- <path>`, open those PR bodies, fold the missing content into the hero (most likely as a sentence under "spec-level structural changes" — priority 2 above).** Do not ship a hero that elides new spec/knowledge content — that is the 2026.04 incident verbatim.
+- If Reconciler's report flags a release-blocker D-item but you emit empty `release_buildhealth.md` anyway: the publish step still succeeds (the compose script does not consult the report), but the maintainer reading the draft has no surfaced caveat. Always cross-check `artifacts/reconciler_report.md` § Drift found before deciding the buildhealth file is safely empty.

--- a/tooling/compose_release_notes.py
+++ b/tooling/compose_release_notes.py
@@ -3,22 +3,30 @@
 Compose release notes for the GitHub draft release.
 
 Reads `.github/release-notes.template.md`, fills placeholders from the
-generation manifest (token usage, post-mortem summary, asset list, build
-stats), then runs `check_sanitization.py` on the rendered output to ensure
-no source-game identifiers or secret-derived strings leak into a public
-release.
+generation manifest (token usage, cache totals, build stats, optional
+build-health caveat), then runs `check_sanitization.py` on the rendered
+output to ensure no source-game identifiers or secret-derived strings
+leak into a public release.
 
 Inputs:
-- --version          release version, e.g. `2026.02`
-- --template         path to the markdown template
-- --usage-jsonl      JSONL file written by orchestrator_run.py (one record per phase
-                       with at minimum: phase, input_tokens, output_tokens, cache_read,
-                       cache_creation, model)
-- --postmortem       path to artifacts/postmortem.md (sanitized post-mortem report)
-- --manifest         path to artifacts/manifest.json — written by the release workflow,
-                       contains module_count, loc, test_summary, rustc_version, generated_at
-- --assets-dir       directory containing the assets to enumerate in the asset table
-- --out              output path for the rendered release notes
+- --version             release version, e.g. `2026.04`
+- --template            path to the markdown template
+- --prev-version        previous release tag (substituted into the compare-view link)
+- --usage-jsonl         JSONL file written by orchestrator_run.py (one record per phase
+                          with at minimum: phase, input_tokens, output_tokens, cache_read,
+                          cache_creation, model)
+- --manifest            path to artifacts/manifest.json — module_count, loc, test_summary,
+                          rustc_version, generated_at
+- --release-hero        path to artifacts/release_hero.md (LLM-authored hero pitch)
+- --release-buildhealth path to artifacts/release_buildhealth.md (LLM-authored caveat
+                          paragraph; empty if no regression to flag)
+- --out                 output path for the rendered release notes
+
+The post-mortem is no longer embedded in the release notes — it ships as a
+separate release asset (`worldsmith-<version>-postmortem.md`) and the
+template's Read-it section links to it. The asset enumeration is also
+gone from the template — GitHub renders the asset list at the bottom of
+every release page natively.
 
 Exit codes:
     0 — success.
@@ -125,35 +133,23 @@ def render_tokens_table(rows: List[PhaseUsage]) -> str:
     return "\n".join([header, *body_lines])
 
 
-def render_asset_table(assets_dir: Path, version: str) -> str:
-    if not assets_dir.exists():
-        return "_(no assets enumerated)_"
-    files = sorted(p for p in assets_dir.iterdir() if p.is_file())
-    if not files:
-        return "_(no assets present)_"
-    rows = ["| File | Size |", "|---|---:|"]
-    for path in files:
-        size_kb = max(1, path.stat().st_size // 1024)
-        rows.append(f"| `{path.name}` | {size_kb:,} KB |")
-    return "\n".join(rows)
+def _format_token_count(n: int) -> str:
+    if n >= 1_000_000:
+        return f"{n / 1_000_000:.1f}M"
+    if n >= 1_000:
+        return f"{n / 1_000:.1f}K"
+    return f"{n:,}"
 
 
-def load_postmortem(path: Optional[Path]) -> str:
-    if path is None:
-        return "_Post-mortem report was not produced for this run._"
-    if not path.exists():
-        # Caller explicitly asked for this file. Refuse to silently substitute
-        # a placeholder — the post-mortem is required CI output per
-        # tooling/agents/postmortem.md § CI output target.
-        raise SystemExit(
-            f"compose_release_notes: --postmortem path does not exist: {path}"
-        )
-    text = path.read_text(encoding="utf-8").strip()
-    if not text:
-        raise SystemExit(
-            f"compose_release_notes: --postmortem file is empty: {path}"
-        )
-    return text
+def render_cache_totals(rows: List[PhaseUsage]) -> Dict[str, str]:
+    if not rows:
+        return {"CACHE_READ_TOTAL": "0", "CACHE_CREATION_TOTAL": "0"}
+    total_read = sum(r.cache_read for r in rows)
+    total_creation = sum(r.cache_creation for r in rows)
+    return {
+        "CACHE_READ_TOTAL": _format_token_count(total_read),
+        "CACHE_CREATION_TOTAL": _format_token_count(total_creation),
+    }
 
 
 def load_manifest(path: Optional[Path]) -> Dict[str, str]:
@@ -217,7 +213,6 @@ def parse_args() -> argparse.Namespace:
         help="Markdown template (default: .github/release-notes.template.md).",
     )
     parser.add_argument("--usage-jsonl", type=Path, default=None)
-    parser.add_argument("--postmortem", type=Path, default=None)
     parser.add_argument("--manifest", type=Path, default=None)
     parser.add_argument(
         "--prev-version",
@@ -233,18 +228,13 @@ def parse_args() -> argparse.Namespace:
              "{{HERO_PITCH}} falls back to a short generic line.",
     )
     parser.add_argument(
-        "--release-whatsnew",
+        "--release-buildhealth",
         type=Path,
         default=None,
-        help="Path to artifacts/release_whatsnew.md (LLM-authored what's-new bullets). "
-             "If absent, {{WHATSNEW_PROSE}} falls back to a generic note pointing at "
-             "the git log.",
-    )
-    parser.add_argument(
-        "--assets-dir",
-        type=Path,
-        required=True,
-        help="Directory containing the assets to be uploaded with the release.",
+        help="Path to artifacts/release_buildhealth.md (LLM-authored 1-paragraph caveat "
+             "naming any Reconciler-flagged coverage regression or other release-blocker "
+             "the operator should know about before publishing). If absent or empty, "
+             "{{BUILD_HEALTH_NOTE}} renders as empty (no caveat is the success case).",
     )
     parser.add_argument("--out", type=Path, required=True)
     parser.add_argument(
@@ -273,14 +263,11 @@ def main() -> int:
             "in this draft before publishing.)_"
         ),
     )
-    whatsnew_prose = load_optional_markdown(
-        args.release_whatsnew,
-        fallback=(
-            "_(Release Editor agent did not produce a what's-new list — see the "
-            "merge commits in `git log` for the raw set of PRs since the previous "
-            "tag and write them up in this draft before publishing.)_"
-        ),
-    )
+    # Build-health note is empty by default — "clean run" is the success case
+    # and adds no caveat paragraph. The fallback is the empty string, NOT a
+    # placeholder marker, so the template's surrounding whitespace renders
+    # cleanly without a maintainer-edit prompt.
+    build_health_note = load_optional_markdown(args.release_buildhealth, fallback="")
     prev_version = args.prev_version or "_(previous tag)_"
 
     replacements = {
@@ -289,12 +276,11 @@ def main() -> int:
         "LOC": manifest["loc"],
         "TEST_SUMMARY": manifest["test_summary"],
         "RUSTC_VERSION": manifest["rustc_version"],
-        "ASSET_TABLE": render_asset_table(args.assets_dir, args.version),
         "TOKENS_TABLE": render_tokens_table(usage),
-        "POSTMORTEM_SUMMARY": load_postmortem(args.postmortem),
         "HERO_PITCH": hero_pitch,
-        "WHATSNEW_PROSE": whatsnew_prose,
+        "BUILD_HEALTH_NOTE": build_health_note,
         "PREV_VERSION": prev_version,
+        **render_cache_totals(usage),
     }
 
     rendered = render(template, args.version, replacements)


### PR DESCRIPTION
The 2026.04 release was published with hand-edited release notes that dropped the PR-by-PR enumeration, moved the token-usage table out of `<details>` into a primary "How it was generated" section, and added a build-health caveat paragraph naming the Reconciler-flagged coverage regression. This PR makes that structure the default for every future release so the next `release.yml` run does not regress to the old verbose changelog form.

Four coupled changes:

**`.github/release-notes.template.md`** — restructured:
- Hero + GIF (unchanged shape)
- New `## How it was generated` block surfacing models/tokens, cache totals (new placeholder), stats, and an optional one-paragraph build-health caveat
- `## Try it` (unchanged) / `## Read it` (adds a compare-view link for PR-by-PR audit)
- The `## What's new since <prev>` PR enumeration is gone; the `<details>Generation report</summary>` postmortem-embed block is gone

**`tooling/compose_release_notes.py`**:
- Drop `--release-whatsnew` / `--postmortem` / `--assets-dir` args and their placeholders. Asset list now renders natively at the bottom of every GitHub release page; the post-mortem ships as a separate release asset linked from Read it
- Add `--release-buildhealth` + `BUILD_HEALTH_NOTE` placeholder. Empty-file is the "clean release" success signal — template renders blank in that case
- Compute CACHE_READ_TOTAL / CACHE_CREATION_TOTAL across phases with a compact "X.YM / X.YK" formatter

**`.github/workflows/release.yml`**:
- Compose-step args updated to match new compose interface
- Package step now copies `artifacts/postmortem.md` into `assets/worldsmith-<VERSION>-postmortem.md` so the Read-it link to it (which the template has long promised but the workflow did not fulfil) actually resolves on the published release page

**`tooling/agents/release_editor.md`**:
- "What to write" rewritten: two files only — `release_hero.md` (3-5 narrative paragraphs, no changelog) and `release_buildhealth.md` (single paragraph or empty)
- Priority list for hero content: gameplay-visible > spec-level structural > pipeline/process
- Concrete worked examples (good opening paragraph and good buildhealth caveat — both lifted from the 2026.04 publish)
- Failure modes updated to reflect the two-file structure and the reconciler-report cross-check requirement before deciding the buildhealth file is safely empty

Validates locally; smoke-tested compose import and `_format_token_count` against the 2026.04 numbers (34.6M cache reads, 1.0M cache creation match the published draft).