### PR TITLE
docs: reframe project as source-of-truth-driven; post-2026.04 direction refresh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,10 @@
 # Worldsmith
 
-Spec-driven game generation experiment. Generate a retro shooter from structured specifications.
+Source-of-truth-driven game generation experiment. Generate a retro shooter from structured, versioned artifacts.
 
 ## Current Status
 
-**Status:** Working, playable (top-down 2D)
+**Status:** Working, playable. First-person raycaster is the default renderer (`spec/45`); topdown 2D remains in the codebase as a debug-only alternate view (`--render-mode=topdown`) because it stays the fastest way to inspect bot pathing and enemy positioning at a glance. Autopilot bot does LoS-gated firing, kiting at melee range, BFS pathfinding, and pickup-seeking detours (`spec/30 § Bot Behavior`). Default level is a reference-derived multi-enemy layout (`spec/25 § Level Layout`).
 
 ## Quick Commands
 
@@ -26,7 +26,7 @@ cargo test --manifest-path generated/game/Cargo.toml
 
 ```
 specs/           # Source of truth (human-readable)
-ir/              # Intermediate representation (YAML)
+ir/              # Intermediate representation and per-module contracts (YAML)
 generated/game/  # Generated Rust code (disposable)
 knowledge/       # Extracted knowledge (public, versioned)
 tests/           # Test scenarios
@@ -44,8 +44,7 @@ reference/       # Research material (private)
 
 ## Current Priority
 
-Focus on specs, knowledge extraction, and gameplay depth — not generation automation.
-Generation is manual (human + Claude session).
+Focus on specs depth, knowledge extraction, and pipeline reliability. Gameplay deltas land via the agent-task → PR flow (`.github/workflows/agent-intake.yml`); full release regens run via `.github/workflows/release.yml`. Manual generation (human + Claude session) is still possible and useful for ad-hoc spec exploration, but the typical loop is now file-an-issue, agents draft a PR, you review and merge — not chat-and-paste.
 
 ## Post-Generation Reconcile
 
@@ -60,9 +59,10 @@ This prevents specs and code from drifting apart across regenerations.
 
 ## Conventions
 
-- Specs are the source of truth, generated code is disposable
-- Interactive generation (human + Claude conversation)
-- Run `python tooling/run_evals.py` after changes
+- For generated game code, `knowledge/`, `specs/`, and `ir/contracts/` are the source-of-truth pack; generated code is disposable
+- Do not force every future domain into specs if another explicit source-of-truth form plus drift checks fits it better
+- Generation runs in two modes — release (full regen from empty `generated/`) and partial (PR-driven, baselined from `generated-snapshot`); see `specs/80_generation_rules.md` § Release vs Partial Generation
+- Run `python tooling/run_evals.py` after manual changes
 - Document decisions in ADR format
 - Rust: safe code only, no unsafe, minimal dependencies
 - Versions are git tags, not hardcoded in docs
@@ -86,7 +86,7 @@ Trust the gate; do not work around it. If the gate fires unexpectedly, the right
 
 When a decision is made during conversation, **automatically**:
 
-1. **Record decision** — Use ADR format (Decision N: Title, Date, Context, Decision, Consequences)
+1. **Record decision** — Use ADR format (Decision N: Title, Date, Context, Decision, Consequences); accepted public workflow/source-of-truth decisions should graduate into tracked docs
 2. **Update agent prompts** — If workflow or process changes, update `tooling/agents/*.md`
 3. **Update README files** — If directory structure or conventions change
 
@@ -95,12 +95,15 @@ Don't wait for user to ask — document immediately when decisions are made.
 ## Multi-Agent System
 
 Agents in `tooling/agents/`:
-- **Orchestrator** — Coordinates work, delegates tasks
+- **Orchestrator** — Coordinates work, delegates tasks (manual-session only; CI flows invoke phases directly)
 - **Extractor** — Extracts knowledge from reference → `knowledge/`
-- **Architect** — Formalizes knowledge into specs
-- **Coder** — Generates code from specs
+- **Architect** — Formalizes knowledge → per-module contracts in `ir/contracts/`
+- **Coder** — Generates Rust from specs + contracts → `generated/game/src/`
+- **Reconciler** — Captures invented constants, contract drift, and unused exports back into `specs/`, `ir/`, and `tooling/agents/` (the agents Reconciler edits include `coder.md` and `reconciler.md` itself when its own checks need tightening)
+- **PostMortem** — Audits the run as a process (token waste, agent-prompt non-compliance, recurring patterns), proposes surgical prompt edits or ADR drafts
+- **Release Editor** — Authors `artifacts/release_hero.md` and `artifacts/release_buildhealth.md` from the diff + PR bodies; everything else in the release notes is templated by `tooling/compose_release_notes.py`
 
-Workflow: `Reference → Extractor → knowledge/ → Architect → specs/ → Coder → generated/`
+Workflow: `Reference → Extractor → knowledge/ → Architect → specs/ + ir/ → Coder → generated/ → Reconciler → specs/' + ir/' → PostMortem → tooling/agents/'`. Release adds a final `Release Editor → artifacts/release_*.md → compose_release_notes.py → published draft` step.
 
 ## Controls
 
@@ -194,5 +197,6 @@ Architect's `PHASE_TOOLS` entry still includes `Bash`; auditing/shrinking it and
 
 ## Known Issues
 
-- Top-down view, not raycasting
 - The `generated-snapshot` branch is force-pushed and orphan-committed each time, so historical snapshots are not retained — only the latest regen-merge baseline lives there. If you need a previous baseline, fall back to the corresponding GitHub Release's `worldsmith-game-X-src.zip`. If a PR sits open for more than 90 days, its `generated-src` artifact expires and the post-merge snapshot can no longer pick it up — `post-merge-snapshot.yml` warns and skips, leaving the previous snapshot in place; refresh manually via `release.yml` if needed.
+- Verify-only merges (touching no source-of-truth paths) do not produce a `generated-src` artifact, so `post-merge-snapshot.yml` warns and leaves the snapshot at the prior regen-merge baseline. Several recent merges (#56/#57/#58/#61/#63) hit this path; the 2026.04 release flow temporarily refreshed `generated-snapshot` manually from the release artifact (see release run 25712621449) before the next pr.yml could baseline correctly. Long-term fix is to add a small post-merge-snapshot fallback that uses the latest GitHub Release tag's `generated/` when no per-PR artifact exists.
+- Test count is not pinned in IR contracts; each release regen has variance in which tests Coder happens to emit (2026.04 shipped 58 tests, the prior PR-mode baseline had 77). Reconciler's release-blocker D-tier catches drops vs `origin/generated-snapshot` and now also vs the prior release tag, but the structural fix (`required_tests:` blocks in `ir/contracts/<module>.yaml`) is unimplemented.

--- a/README.md
+++ b/README.md
@@ -1,23 +1,29 @@
 # worldsmith
 
-> Generate a playable retro shooter from spec files — and prove the specs are sufficient by regenerating from scratch every release.
+> Generate a playable retro shooter from versioned source-of-truth artifacts — and prove they are sufficient by regenerating from scratch every release.
 
-![worldsmith gameplay](https://github.com/RuslanMingaliev/worldsmith/releases/download/2026.02/worldsmith-2026.02-gameplay.gif)
+![worldsmith gameplay](https://github.com/RuslanMingaliev/worldsmith/releases/download/2026.04/worldsmith-2026.04-gameplay.gif)
 
-*Top-down gameplay from release [`2026.02`](https://github.com/RuslanMingaliev/worldsmith/releases/tag/2026.02). The Rust binary in this clip was generated end-to-end from the specs in this repo.*
+*First-person gameplay from release [`2026.04`](https://github.com/RuslanMingaliev/worldsmith/releases/tag/2026.04). The Rust binary in this clip was generated end-to-end from the specs in this repo, including the column-based raycaster renderer (`specs/45`) and the autopilot bot's kiting / pathfinding behavior (`specs/30`).*
 
 ## What this is
 
-worldsmith is an experiment in spec-driven game generation. A pipeline takes extracted mechanics knowledge, formalises it into specs, and regenerates a Rust game from those specs. Two releases shipped so far (`2026.01`, `2026.02`); current scope is a top-down 2D shooter with one level, one enemy type, hitscan combat, momentum-based movement, and an autopilot test runner — not a full game, not multi-level, not first-person yet.
+worldsmith is an experiment in operating a generated game from public, reviewable source-of-truth artifacts. The game mechanics chain is `reference/` → `knowledge/` → `specs/` + per-module `ir/contracts/` → disposable Rust; the release chain proves that this pack is sufficient by rebuilding `generated/` from empty on every tagged version.
 
-The proposition the project tests: *can a structured spec pack alone be enough to reproduce a working game?* — and the discipline that makes the answer trustworthy: sanitization gates, post-generation reconciliation, full regen on every release.
+Four releases have shipped (`2026.01` through `2026.04`). Current scope is a first-person column-based raycaster with multiple enemies per level, hitscan combat, momentum-based movement, pickups, and an autopilot bot that does line-of-sight-gated firing, kiting at melee range, BFS pathfinding around walls, and pickup-seeking detours. The top-down view remains in the codebase as `--render-mode=topdown` because it is still the fastest debug view for bot pathing, sprite positions, level geometry, and autopilot decisions.
+
+The proposition the project tests: *can a structured source-of-truth pack be enough to reproduce a working, non-trivial game?* The answer is only trustworthy if the process is strict: sanitization gates, post-generation reconciliation, full regen from empty `generated/` on every release, and a multi-agent pipeline whose phases (Extractor / Architect / Coder / Reconciler / PostMortem / Release Editor) are each runnable from CI or by hand.
+
+The scope of "spec-driven" is deliberate, not dogmatic. For mechanics and generated Rust, specs and IR are the source of truth. For domains that are not naturally deterministic prose-and-number artifacts (for example future visual identity work), the right source of truth may be a curated corpus plus evals instead. The project rule is not "everything must be a spec"; it is "each domain must have an explicit, versioned source of truth and checks that catch drift."
 
 ## Why it might be interesting
 
-- **The chain closes end-to-end.** `reference/` → `knowledge/` (1,185 LoC across 7 files) → `specs/` (2,304 LoC across 12 files) → `ir/module_plan.yaml` (11 modules with explicit dependency graph) → `generated/game/src/` (3,970 LoC of Rust). Every release tag is a full regeneration from scratch, not an incremental edit.
-- **Honest validation gates.** [`tooling/check_sanitization.py`](tooling/check_sanitization.py) rejects source-game proper nouns and identifiers in public artifacts. [`tooling/validate_specs.py`](tooling/validate_specs.py) *refuses* to let `knowledge/` change when `reference/` is empty — so an agent cannot "remember" mechanics from training data and pass them off as extracted knowledge. Both gates run in CI, not just in docs.
-- **Reconciliation, not just generation.** When the Coder agent invents constants the spec didn't pin, the Reconciler captures them back into [`specs/25_game_tuning.md`](specs/25_game_tuning.md). Spec drift is a first-class artifact (ADRs, "deferred" markers) instead of being papered over.
-- **Incremental regeneration.** [`tooling/partial_regen.py`](tooling/partial_regen.py) computes the impact of a spec change and only regenerates affected modules, reusing the previous release as baseline — no rebuilding the world for a one-line edit.
+- **The chain closes end-to-end.** `reference/` → `knowledge/` (~1,879 LoC across 12 files) → `specs/` (~3,639 LoC across 14 files) + `ir/contracts/` (per-module formal contracts) → `generated/game/src/` (~3,607 LoC of Rust across 14 modules at `2026.04`). Every release tag is a full regeneration from empty `generated/`, not an incremental edit — a `release.yml` invocation runs the agent phases from scratch and produces a binary, source archive, demo GIF, release notes, and PostMortem as paired evidence.
+- **The pipeline is part of the artifact.** `tooling/agents/`, `.github/workflows/pr.yml`, `.github/workflows/release.yml`, `generated-snapshot`, and the release-note composer are not supporting scripts around the experiment; they are the experiment's operational surface. PR-mode answers "what changed from this source-of-truth diff?", while release-mode answers "can the whole pack reproduce the game from zero?"
+- **Honest validation gates.** [`tooling/check_sanitization.py`](tooling/check_sanitization.py) rejects source-game proper nouns and identifiers in public artifacts (including release notes — the 2026.04 publish hit this when the release-editor agent quoted an identifier-prefix verbatim, and the gate blocked it). [`tooling/validate_specs.py`](tooling/validate_specs.py) *refuses* to let `knowledge/` change when `reference/` is empty — an agent cannot "remember" mechanics from training data and pass them off as extracted knowledge.
+- **Reconciliation, not just generation.** When the Coder agent invents constants the spec didn't pin or simplifies a contract shape, the Reconciler captures it back into [`specs/25_game_tuning.md`](specs/25_game_tuning.md) and the relevant [`ir/contracts/<module>.yaml`](ir/contracts/). PostMortem then audits the run as a process and proposes surgical edits to the agent prompts themselves — so the next regen does not repeat the same class of mistake.
+- **Two-mode regeneration.** Releases regen the full tree from empty `generated/` (proves the source-of-truth pack is self-sufficient). PRs use partial regen — [`tooling/partial_regen.py`](tooling/partial_regen.py) computes the affected module set from a spec/IR diff, baselines from a long-lived `generated-snapshot` branch that's force-pushed after every regen-bearing merge, and only re-emits the affected modules. Both paths converge on the same agent prompts; the mode is the variable.
+- **Agent-task driven gameplay slices.** Substantial features (the raycaster migration, the smart-bot rewrite, the new default level) shipped as multi-PR series filed via [`/create-agent-task`](.claude/skills/create-agent-task) → [`.github/workflows/agent-intake.yml`](.github/workflows/agent-intake.yml) → Extractor + Architect drafts a PR → maintainer reviews, merges, repeats. The release-notes generator groups such series into a single thematic bullet for the user.
 
 ## How it works
 
@@ -28,19 +34,22 @@ The proposition the project tests: *can a structured spec pack alone be enough t
    knowledge/        sanitized public mechanics notes
        │
        ▼   Architect
-   specs/            enforceable design contracts
-       │
-       ▼   (formalisation)
-   ir/               machine-oriented module plan
+   specs/, ir/       enforceable design + per-module formal contracts
        │
        ▼   Coder
    generated/game/   disposable Rust
        │
-       ▼   Reconciler · PostMortem
-   specs/, ADRs      spec drift captured back
+       ▼   Reconciler
+   specs/', ir/'     captured drift folded back into source-of-truth
+       │
+       ▼   PostMortem
+   tooling/agents/'  surgical prompt edits informed by this run's pain
+       │
+       ▼   Release Editor                    (release.yml only)
+   release_*.md      hero + buildhealth caveat → composed release notes
 ```
 
-Each arrow is owned by a named agent — see [`tooling/agents/`](tooling/agents/) for the prompts. Generation is normally driven manually in a Claude Code session, but the same agents are also wired into a GitHub Issues → PR workflow ([`.github/workflows/agent-intake.yml`](.github/workflows/agent-intake.yml) + [`pr.yml`](.github/workflows/pr.yml)) that posts a recorded demo GIF and inline review suggestions on eligible source-of-truth PRs (same-repo PRs that touch `specs/`, `knowledge/`, `ir/`, or `tooling/agents/`; fork PRs are skipped because the OAuth secret isn't available to them). Full CI architecture lives in [CLAUDE.md](CLAUDE.md).
+Each arrow is owned by a named agent — see [`tooling/agents/`](tooling/agents/) for the prompts. CI runs the agents through [`.github/workflows/release.yml`](.github/workflows/release.yml) (full regen, publishes a draft release on GitHub) and [`.github/workflows/agent-intake.yml`](.github/workflows/agent-intake.yml) + [`pr.yml`](.github/workflows/pr.yml) (file an issue → agents draft a PR → partial regen + cargo build/test + recorded demo GIF on every push). Manual generation in a Claude Code session is still supported and useful for ad-hoc spec exploration, but the typical loop is now `gh issue create` → review → merge, not chat-and-paste. Full CI architecture lives in [CLAUDE.md](CLAUDE.md).
 
 ## Try it
 
@@ -54,45 +63,48 @@ The repo does not contain a buildable game — `generated/` is gitignored on pri
 **Build from the generated source.** Same release page, grab `worldsmith-game-<tag>-src.zip`:
 
 ```bash
-unzip worldsmith-game-2026.02-src.zip -d worldsmith-game
+unzip worldsmith-game-2026.04-src.zip -d worldsmith-game
 cargo run --release --manifest-path worldsmith-game/Cargo.toml
 ```
 
-Controls: `WASD` move, arrows turn, `Space` fire, `ESC` quit.
+Controls: `WASD` move, arrows turn, `Space` fire, `ESC` quit. Default renderer is the first-person raycaster; pass `--render-mode=topdown` for the debug 2D view.
 
-The source archive is the snapshot of generated Rust produced from the specs at that tag — read it as the answer to "what does this pipeline actually emit?". To regenerate it from scratch yourself, run the agent pipeline (see [`tooling/agents/`](tooling/agents/) and [CLAUDE.md](CLAUDE.md)).
+The source archive is the snapshot of generated Rust produced from the specs at that tag — read it as the answer to "what does this pipeline actually emit?". To regenerate it from scratch yourself, dispatch [`release.yml`](.github/workflows/release.yml) with a new version input, or run the phases via [`tooling/orchestrator_run.py`](tooling/orchestrator_run.py) locally (see [`tooling/agents/`](tooling/agents/) and [CLAUDE.md](CLAUDE.md)).
 
 ## Releases
 
-Tags follow the `yyyy.vv` scheme — `yyyy` is the year, `vv` is a zero-padded sequence within that year. Each tagged release is built from a clean regeneration to prove the specs are self-sufficient, and ships:
+Tags follow the `yyyy.vv` scheme — `yyyy` is the year, `vv` is a zero-padded sequence within that year. Each tagged release is built from a clean regeneration to prove the source-of-truth pack is self-sufficient, and ships:
 
 - pre-built binaries for Linux / macOS / Windows
 - the generated Rust source as `*-src.zip`
 - a recorded gameplay GIF
 - a PostMortem write-up of the run (what the agents did, what hurt, what got reconciled)
 
-Current tags: [`2026.01`](https://github.com/RuslanMingaliev/worldsmith/releases/tag/2026.01), [`2026.02`](https://github.com/RuslanMingaliev/worldsmith/releases/tag/2026.02). Pre-release checks live in [`evals/`](evals/).
+Current tags: [`2026.01`](https://github.com/RuslanMingaliev/worldsmith/releases/tag/2026.01), [`2026.02`](https://github.com/RuslanMingaliev/worldsmith/releases/tag/2026.02), [`2026.03`](https://github.com/RuslanMingaliev/worldsmith/releases/tag/2026.03), [`2026.04`](https://github.com/RuslanMingaliev/worldsmith/releases/tag/2026.04). Pre-release checks live in [`evals/`](evals/).
 
 ## Core principles
 
-- Specs are the source of truth.
-- Generated code is disposable.
-- Regeneration is incremental by default; releases regenerate from scratch.
-- Evaluation is mandatory.
-- Reconcile after generation — sync specs with what was actually produced.
+- Every domain needs an explicit source of truth. For generated game code, that is `knowledge/`, `specs/`, and `ir/contracts/`.
+- Specs are not a dumping ground for every future asset or aesthetic judgment; use the source-of-truth form the domain can actually sustain.
+- Generated code is disposable; release artifacts are evidence of what a source-of-truth pack produced at a tag.
+- Two modes by intent: PR regen is partial and baselined from the most recent snapshot; release regen is full from empty `generated/` and proves the source-of-truth pack is sufficient. Don't blur the modes.
+- Reconcile after generation — sync specs and per-module IR contracts with what was actually produced. Drift is captured back, not papered over.
+- PostMortem audits the run as a process and writes its findings into the agent prompts themselves — recurring failure modes become checklist items, not folklore.
 - Versions are git tags following `yyyy.vv`, not hardcoded in generated code.
+- Public release notes are content-driven (read the diff first, attribute to PRs second) and lean — the GitHub compare view handles the audit trail, the hero handles the story.
 
 ## Repository layout
 
 <details>
 <summary>Click to expand</summary>
 
-- `specs/` — source of truth for design and generation constraints
-- `ir/` — compact machine-oriented representation derived from specs
+- `specs/` — human-readable design and generation constraints
+- `ir/` — compact machine-oriented representation and per-module contracts derived from specs
 - `knowledge/` — extracted knowledge from reference (public)
 - `tests/` — test scenarios
 - `evals/` — harness evaluation criteria
-- `tooling/` — scripts and agent prompts
+- `tooling/` — scripts, validators, release composition, and agent prompts
+- `.github/workflows/` — PR-mode partial regen, release-mode full regen, post-merge snapshots, and PR demo artifact cleanup
 - `generated/` — disposable generated implementation (gitignored)
 - `work/` — private notes, decisions (gitignored)
 - `reference/` — research material (gitignored, may be empty)

--- a/evals/README.md
+++ b/evals/README.md
@@ -85,7 +85,7 @@ This separation is inspired by:
 - **Acceptance testing** — verify product meets requirements
 - **CI/CD quality gates** — criteria for release
 
-Applied to spec-driven code generation: evals verify the pipeline can reliably produce correct code from specifications.
+Applied to source-of-truth-driven code generation: evals verify the pipeline can reliably produce correct code from the public knowledge/spec/IR pack.
 
 ## Related
 

--- a/specs/00_project_goal.md
+++ b/specs/00_project_goal.md
@@ -2,18 +2,21 @@
 
 ## Vision
 
-Build a spec-driven pipeline that generates a classic retro shooter from structured specifications.
+Build a source-of-truth-driven pipeline that generates a classic retro shooter from structured, versioned artifacts.
 
-The specifications are derived from reference material through research and extraction. The generated game should feel authentic to the genre — the community should recognize the inspiration.
+For generated game code, the operational source of truth is mechanics knowledge, human-readable specs, and per-module IR contracts derived from reference material through research and extraction. The generated game should feel authentic to the genre — the community should recognize the inspiration without the public artifacts leaking source-game identifiers or private reference content.
 
 ## Why
 
-The project explores whether a game can be reconstructed as a family of design constraints and implementation rules rather than as a single codebase.
+The project explores whether a game can be reconstructed as a family of source-of-truth artifacts and generation rules rather than as a single hand-maintained codebase.
 
 The deeper objective is to separate:
-- design knowledge (specs)
+- extracted mechanics knowledge (`knowledge/`)
+- design and generation constraints (`specs/`)
+- machine-oriented module contracts (`ir/`)
 - implementation strategy (generation rules)
 - generated artifacts (disposable code)
+- run feedback (Reconciler and PostMortem updates that close the loop)
 
 ## Project Phases
 
@@ -35,31 +38,36 @@ Add plugin/skill architecture for spec modifications:
 
 ## Generation Model
 
-Generation is human-driven: a maintainer triggers code generation in a Claude Code session using specs and IR as context, verifies results, and commits.
+Generation is pipeline-driven with a human maintainer in the loop. Gameplay and spec deltas normally enter through an issue/PR flow (`agent-intake.yml` → `pr.yml`) that runs the relevant agents, performs partial regeneration against the latest `generated-snapshot` baseline, builds/tests the generated game, records a demo GIF, and surfaces Reconciler/PostMortem edits for maintainer review.
+
+Manual generation in a Claude Code session remains supported for ad-hoc exploration, but it is no longer the primary operating model.
 
 ### Iterative Development
 
-During development, prefer efficiency:
-- Repair over regeneration
-- Incremental module updates
-- Preserve working code
+During development, prefer efficiency while keeping the source-of-truth chain explicit:
+- repair hand-written tooling directly when generation is not involved
+- use partial regeneration for source-of-truth PRs
+- preserve unaffected generated modules by baselining from `generated-snapshot`
+- capture any generated drift back into specs and IR contracts
 
 ### Release Generation
 
 Each tagged release must:
 - Regenerate all code from scratch
 - Produce a "generated sample" — a playable artifact
-- Prove that specs alone are sufficient
+- Publish the generated source alongside the binary
+- Record release notes and run feedback as first-class outputs
+- Prove that the source-of-truth pack is sufficient
 
 The `generated/` folder is always disposable. A release proves reproducibility.
 
 ### Reconcile
 
-After generation, reconcile code with specs: capture invented constants into `specs/25_game_tuning.md`, mark unimplemented features as deferred, and document design decisions.
+After generation, reconcile code with the source-of-truth pack: capture invented constants into `specs/25_game_tuning.md`, update per-module `ir/contracts/` when contract shape drifted, mark unimplemented features as deferred, and document design decisions or agent-prompt fixes when a run exposes a repeated process failure.
 
 ### Automation
 
-Generation automation (LLM executor, CI-based regeneration) is not a current priority. The focus is on spec quality and knowledge depth. Automation becomes worthwhile when the project outgrows manual generation.
+Automation is now part of what the project is testing. The priority is not to maximize automation for its own sake; it is to make the automated path auditable enough that a maintainer can trust the artifacts it produces. CI generation, partial-regeneration planning, post-merge snapshots, release composition, and agent prompt updates are therefore source-of-truth-adjacent work, not chores outside the experiment.
 
 ## Current Scope
 
@@ -70,7 +78,8 @@ The generated game should have:
 - At least one weapon
 - At least one enemy type
 - Win/exit condition
-- Graphical rendering (2D top-down or raycasting)
+- First-person column-based raycaster as the default renderer
+- Top-down renderer retained as a debug-only alternate mode
 
 Scope evolves with the specs. See git history for changes.
 
@@ -78,21 +87,24 @@ Scope evolves with the specs. See git history for changes.
 
 The project is explicitly not trying to do:
 
-- Advanced AI behaviors
+- Advanced enemy AI behaviors
 - Multiple weapon types
 - Procedural level generation
-- Graphical fidelity beyond functional
+- Graphical fidelity beyond the current flat-color raycaster
 - One-shot perfect generation
 
 These may become goals later. Non-goals evolve with the project.
 
 ## Source of Truth
 
-The source of truth for the system is:
+The source of truth for generated game code is:
 1. spec files in `specs/`
-2. IR files in `ir/`
+2. IR files and per-module contracts in `ir/`
+3. sanitized mechanics knowledge in `knowledge/`
 
-Reference material informs spec creation but is not the operational source of truth. Specs should be self-sufficient for generation.
+Reference material informs spec creation but is not the operational source of truth. The public source-of-truth pack should be self-sufficient for generation.
+
+This does not imply that every future domain must be forced into specs. If a domain cannot be faithfully reproduced from prose constraints and numeric contracts, it needs its own explicit source-of-truth form and drift checks rather than pretending it fits the game-code generation model.
 
 ## Versioning
 

--- a/specs/10_system_model.md
+++ b/specs/10_system_model.md
@@ -2,15 +2,17 @@
 
 ## Overview
 
-The system is a small spec-driven generation pipeline for a retro shooter prototype.
+The system is a source-of-truth-driven generation pipeline for a retro shooter prototype.
 
-The pipeline has five major parts:
+The pipeline has seven major parts:
 
 1. Reference Corpus
-2. Spec Pack
-3. IR Builder
-4. Code Generator
-5. Evaluator and Repair Loop
+2. Knowledge Pack
+3. Spec Pack
+4. IR Contracts
+5. Code Generator
+6. Evaluator and Repair Loop
+7. Reconciler / PostMortem / Release Editor Loop
 
 ## Components
 
@@ -24,7 +26,17 @@ Responsibility:
 - help identify stable mechanics and constraints
 - serve as a comparison baseline
 
-### 2. Spec Pack
+### 2. Knowledge Pack
+
+Location:
+- `knowledge/`
+
+Responsibility:
+- store sanitized mechanics findings extracted from private reference material
+- provide public citations for specs without leaking source identifiers
+- reject "remembered" genre knowledge when `reference/` is empty
+
+### 3. Spec Pack
 
 Location:
 - `specs/`
@@ -35,20 +47,21 @@ Responsibility:
 - define constraints and invariants
 - define allowed generation strategy
 
-This is the human-readable source of truth.
+This is the human-readable source of truth for generated game behavior and generation constraints.
 
-### 3. IR Builder
+### 4. IR Contracts
 
 Location:
 - `ir/`
 
 Responsibility:
 - compress specs into a small, generation-oriented representation
+- pin module responsibilities, exported types/functions, dependencies, and behavioral contracts
 - stabilize terminology across prompts
 - reduce token waste
-- make incremental generation easier
+- make partial regeneration and Reconciler drift checks tractable
 
-### 4. Code Generator
+### 5. Code Generator
 
 The generator emits a small Rust crate under `generated/game/`. Module-level structure is pinned in `ir/module_plan.yaml`. As of slice 1 of the FPS migration (specs/45), the rendering surface is split across three modules: **`presentation`** owns window-and-frame constants; **`renderer`** owns the HUD, the game-over border, and the debug-only 2D top-down draw path; **`raycaster`** owns the column-based first-person draw path. `main.rs` chooses between `renderer::draw` and `raycaster::draw` per frame based on the `--render-mode` flag. The default is `raycaster` (flipped from `topdown` in slice 5) — `cargo run` with no flag, every autopilot scenario, and the canonical PR-preview GIF dispatch to the raycaster pipeline. `--render-mode=topdown` is permanently retained as a debug-only alternate mode for development use (specs/45 § Implementation Status); the HUD and game-over border draw on top of either pipeline so they remain identical between modes.
 
@@ -59,23 +72,23 @@ Location:
 Target language: **Rust** (stable, safe subset)
 
 Generation method: **LLM-based** (Claude)
-- Uses specs and IR as primary context
-- Human-guided interactive generation in Claude Code session
-- Prompts refined iteratively based on results
+- Uses knowledge, specs, and IR contracts as primary context
+- Runs through CI in PR mode (partial regeneration) and release mode (full regeneration)
+- Manual Claude Code generation remains available for exploration
+- Prompts are refined from Reconciler/PostMortem findings
 
-Module interfaces: **Implicit**
-- Specs describe module responsibilities, not exact signatures
-- LLM infers necessary types, functions, and contracts
-- Rust compiler catches incompatibilities during build
-- Can evolve to explicit contracts if integration problems emerge
+Module interfaces: **Contracted**
+- `ir/module_plan.yaml` pins generated modules and dependencies
+- `ir/contracts/*.yaml` pins module responsibilities, public surface, and key behavior
+- Reconciler captures contract drift after generation instead of leaving it implicit
 
 Responsibility:
 - generate implementation for a requested module or slice
-- follow the current specs and IR
+- follow the current source-of-truth pack
 - avoid rewriting unrelated modules
 - produce explicit, testable code
 
-### 5. Evaluator
+### 6. Evaluator
 
 Location:
 - `evals/`
@@ -86,14 +99,29 @@ Responsibility:
 - verify structural invariants
 - produce reports that guide repair
 
+### 7. Reconciler / PostMortem / Release Editor
+
+Location:
+- `tooling/agents/`
+- `.github/workflows/`
+
+Responsibility:
+- capture generated-code drift back into specs and IR contracts
+- capture process drift back into agent prompts or ADR drafts
+- compose release notes from the actual diff, PR bodies, and run artifacts
+- keep PR-mode and release-mode regeneration distinct
+
 ## Data Flow
 
-Reference -> Specs -> IR -> Generation -> Evals -> Repair
+Reference -> Extractor -> knowledge/ -> Architect -> specs/ + ir/contracts/ -> Coder -> generated/ -> Evals -> Reconciler -> specs/ + ir/ -> PostMortem -> tooling/agents/
+
+Release mode adds: generated/ + run artifacts -> Release Editor -> release notes.
 
 ## Architectural Invariants
 
-- specs remain the primary source of truth
+- the public source-of-truth pack for generated game code is `knowledge/`, `specs/`, and `ir/contracts/`
 - generated code remains disposable
-- unrelated modules are not rewritten during local generation
+- unrelated modules are not rewritten during partial regeneration
 - evaluation always runs after generation
-- repair is preferred over broad rewrite
+- PR mode and release mode answer different questions and must not be blurred
+- Reconciler/PostMortem findings are folded back into source-of-truth or process docs instead of becoming folklore

--- a/specs/80_generation_rules.md
+++ b/specs/80_generation_rules.md
@@ -49,7 +49,7 @@ For each tagged release:
 - Regenerate everything from specs + IR
 - Produce a "generated sample" artifact
 
-This proves that specs are self-sufficient. The generated sample can be published as a playable release.
+This proves that the public source-of-truth pack is self-sufficient. The generated sample can be published as a playable release.
 
 ## Token Efficiency Rules
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,6 +1,8 @@
 # Specs
 
-Specifications are the source of truth for what the game does.
+Specifications are the human-readable source of truth for generated game behavior and generation constraints. They work together with sanitized mechanics knowledge in `knowledge/` and machine-oriented contracts in `ir/`.
+
+Specs are not a universal container for every possible project domain. If a future domain cannot be made reproducible through prose constraints and numeric contracts, define a separate explicit source of truth and drift checks for that domain instead of burying it here.
 
 ## Numbering Convention
 
@@ -60,6 +62,7 @@ Structure:
 - Success criteria → `evals/`
 - Implementation details → `generated/`
 - Research/findings → `work/`
+- Non-deterministic asset identity that needs a corpus/eval source of truth rather than prose specs
 
 ## Related
 

--- a/tooling/agents/README.md
+++ b/tooling/agents/README.md
@@ -1,29 +1,45 @@
 # Agent System
 
-Multi-agent architecture for spec-driven game generation.
+Multi-agent architecture for source-of-truth-driven game generation.
 
 ## Agents
 
 | Agent | File | Responsibility |
 |-------|------|----------------|
-| **Orchestrator** | `orchestrator.md` | Coordination, delegation, escalation |
+| **Orchestrator** | `orchestrator.md` | Coordination, delegation, escalation in manual sessions |
 | **Extractor** | `extractor.md` | Extract knowledge from reference |
-| **Architect** | `architect.md` | Design specs and IR |
-| **Coder** | `coder.md` | Generate code |
-| **Reconciler** | `reconciler.md` | Reconcile code with specs after generation |
+| **Architect** | `architect.md` | Design specs and per-module IR contracts |
+| **Coder** | `coder.md` | Generate Rust from specs and contracts |
+| **Reconciler** | `reconciler.md` | Reconcile generated code with specs, IR contracts, and prompt expectations |
 | **PostMortem** | `postmortem.md` | Audit the run as a process; propose changes to agent prompts / tooling / ADRs |
+| **Release Editor** | `release_editor.md` | Compose release hero/build-health notes from diffs, PRs, and run artifacts |
 
 ## Workflow
 
 ```
-Reference ──► Extractor ──► knowledge/ ──► Architect ──► Coder ──► Evals ──► Reconciler ──► PostMortem
-             (private)      (public)           │            │                    │              │
-                                               ▼            ▼                   ▼              ▼
-                                            specs/      generated/        specs updated   process recs
-                                              ir/                         (closes loop)   (closes meta-loop)
+Reference ──► Extractor ──► knowledge/ ──► Architect ──► specs/ + ir/contracts/
+             (private)      (public)                          │
+                                                              ▼
+                                                           Coder ──► generated/
+                                                              │
+                                                              ▼
+                                                        Reconciler ──► specs/ + ir/ + agent prompt edits
+                                                              │
+                                                              ▼
+                                                        PostMortem ──► process findings / ADR drafts
+                                                              │
+                                                              ▼
+                                                     Release Editor ──► release_*.md (release mode only)
 ```
 
 **Key:** Extractor sanitizes findings before writing to `knowledge/` (source references are kept private).
+
+The same phase prompts are used in two modes:
+
+- **PR mode:** `pr.yml` fetches the latest `generated-snapshot`, runs partial regeneration for impacted modules, builds/tests the generated game, records a demo GIF, and exposes Reconciler/PostMortem edits for maintainer review.
+- **Release mode:** `release.yml` deletes `generated/`, regenerates the full game from the source-of-truth pack, packages binaries/source, records the canonical gameplay GIF, and asks Release Editor to produce the release narrative.
+
+Manual Claude Code sessions can still invoke the prompts directly, but they are now the exploration path, not the canonical release path.
 
 ## Shared State (Filesystem)
 
@@ -35,17 +51,18 @@ knowledge/          # Public findings, no source refs (Extractor writes)
 tests/              # Test scenarios
 evals/              # Evaluation criteria
 reference/          # Read-only reference material (private)
+tooling/agents/     # Agent prompts; Reconciler/PostMortem may propose surgical edits
 ```
 
 ## Quality Control
 
-1. **Automated:** Build, test, evals
-2. **Cross-agent:** Architect reviews Extractor, etc.
-3. **Human:** Architectural decisions, escalations
+1. **Automated:** sanitization, spec validation, impact analysis, build/test, demo recording
+2. **Cross-agent:** Reconciler captures generation drift; PostMortem captures process drift
+3. **Human:** maintainer reviews generated PRs, reconciler diffs, release notes, and architectural decisions
 
 ## Usage
 
-Each agent prompt is a system instruction. Load the prompt and give the agent a specific task.
+Each agent prompt is a system instruction. In CI, `tooling/orchestrator_run.py` loads the phase prompt and constrains the allowed tools per phase. In a manual session, load the prompt and give the agent a specific task.
 
 Example:
 ```
@@ -54,6 +71,6 @@ Example:
 User: Start extraction cycle for player movement.
 ```
 
-## Decision Log
+## Decision Records
 
-Design decisions are recorded in ADR format in the project's private notes.
+Design decisions are recorded in ADR format. Run-local drafts may stay in private notes, but accepted decisions that define public workflow or source-of-truth rules should graduate into tracked docs in the same change that depends on them.


### PR DESCRIPTION
The "spec-driven" framing has been the project's tagline since the proof-of-concept but is no longer accurate. Four releases in:

- The operational source of truth is a **pack** — `knowledge/` + `specs/` + `ir/contracts/` — not just specs.
- The **pipeline** (`tooling/agents/`, `release.yml`, `pr.yml`, `generated-snapshot`) is part of what the project demonstrates, not supporting scripts around it.
- **Future domains that are not naturally deterministic prose-and-number artifacts** (the textures work currently being scaffolded under `evals/textures/`, for example) may need a different source-of-truth form — a curated corpus plus evals — rather than being forced into spec prose. The project rule going forward is *"each domain has an explicit, versioned source of truth and drift checks"*, not *"everything is a spec"*.

This PR reframes the public-facing direction across eight files: the two top-level READMEs (`README.md`, `CLAUDE.md`), the three core specs (`specs/00`, `specs/10`, `specs/80`), and the three subdirectory READMEs (`specs/README.md`, `tooling/agents/README.md`, `evals/README.md`).

Key shifts:
- Hero GIF and "current scope" prose refreshed to 2026.04 (first-person raycaster, smart bot, multi-enemy default level, four releases shipped).
- `README.md` "What this is" + "Why it might be interesting" rewritten to lead with the source-of-truth-pack framing and add two new bullets: "the pipeline is part of the artifact" and "agent-task driven gameplay slices".
- `CLAUDE.md` Current Priority rewritten — pipeline-driven flow (`agent-intake.yml` → `pr.yml` for slices; `release.yml` for full regens) is now the typical loop; manual Claude session is the exception. Known Issues drops the stale "top-down, not raycasting" item and adds two new ones (verify-only-merge snapshot gap, unpinned test counts in IR contracts).
- `specs/00` Vision/Why/Generation Model rewritten. `specs/10` pipeline expanded 5 → 7 components (Knowledge Pack and Reconciler/PostMortem/Release Editor loop now first-class). `specs/80` reframes "specs are self-sufficient" → "the public source-of-truth pack is self-sufficient".
- `specs/README.md` adds the explicit rule that specs aren't a universal container; `tooling/agents/README.md` adds Release Editor + dual-mode framing; `evals/README.md` gets a one-line wording fix.

**Heads up on CI cost.** This PR touches `specs/00_project_goal.md`, `specs/10_system_model.md`, and `specs/80_generation_rules.md`, all of which are in `partial_regen.py`'s `global` trigger list. `pr.yml`'s `regenerate-and-build` job will therefore perform a **full regen of all 14 modules** — same scope as a release run, ~50 min wall + release-level token spend. The expected outcome is a near-zero-diff regen because the changes here are prose-only and do not affect what the Coder emits; that zero-diff is itself a useful signal that this PR's reframe does not accidentally drift the generated game.

No `generated/` changes are included in this PR (gitignored, regenerable). The branch builds on top of the merged 2026.04 drift PR (`#64`, commit `898455c`).