### PR TITLE
agent: refresh from issue #67

### DIFF
--- a/ir/contracts/_shared.yaml
+++ b/ir/contracts/_shared.yaml
@@ -298,6 +298,7 @@ frame_update_order:
   - "// pickup-collision check (specs/60 § Per-Frame Pickup Check, knowledge/pickups.md § Pickup Touch Detection + § Cap Behavior). Iterate state.level.pickups; for the first active pickup with pos.distance_to(state.player.pos) < PICKUP_RADIUS_TILES whose acceptance condition holds (Health: state.player.health < PLAYER_MAX_HEALTH; Ammo: state.player.ammo < PLAYER_AMMO_MAX), set pickup.active=false, call player_state::take_health_pickup or take_ammo_pickup based on pickup.kind, and call visual_effects::increment_pickup_tint(&mut state.fx) (specs/40 § Pickup Tint Screen Flash)."
   - "for enemy in &mut state.enemies: enemy_logic::update(enemy, &mut state.player, &state.level, &mut state.fx, dt)"
   - "if input.fire && state.player.alive: weapon_system::fire(&mut state.player, &mut state.enemies, &state.level, &mut state.fx) -- the per-shot cooldown gate is INSIDE fire(), keyed off player.time_since_fire. Ammo gate is also inside fire(): if player.ammo == 0, fire() returns without side effects after the cooldown gate."
+  - "// specs/25 § Enemy drop on death + specs/60 § Enemy Ammo Drops: scan state.enemies AFTER the enemy update loop AND after weapon_system::fire (so a same-frame kill drops the pickup that frame, not next frame). For each enemy where !enemy.alive AND !enemy.ammo_drop_spawned, push Pickup { kind: PickupKind::Ammo, pos: enemy.pos, active: true } onto state.level.pickups and set enemy.ammo_drop_spawned = true. Coder may use a two-pass shape (collect dropped positions, then push) to side-step split-borrow ergonomics; both shapes meet the contract. The behavior is `exactly one Pickup pushed per dead trooper, at the trooper's death position, in the same frame death is detected`. Re-running this scan on subsequent frames is a no-op because ammo_drop_spawned remains true. The drop is collectible by the existing per-frame pickup check on the next frame (the pickup check ran earlier this frame, before enemy update + weapon_system::fire, so the new Pickup is not seen until the next frame's pickup-check step)."
   - "player_state::decay_damage_tint(&mut state.player, dt)"
   - "visual_effects::tick(&mut state.fx, dt)"
   - "// specs/20 § Game Over Flow: the game-over DECISION (player alive becomes false; or pos.distance_to(level.exit) < EXIT_RADIUS) and the loop-EXIT ACTION (running = false) MUST be in separate iterations of the main loop. Implementation pattern: the decision sets `state.game_over_at = Some(elapsed_seconds)`. The exit action runs only when `now - game_over_at >= GAME_OVER_HOLD_SEC` from specs/25 § Visual. Until then, the loop continues to call update + draw with `game_over` set so the colored border keeps rendering. Without this separation, the implementation flips running=false on the same tick the win/lose state is detected and the colored border renders for zero frames."
@@ -327,6 +328,32 @@ service_emit_decisions:
       pins the signature: "the corpse marker is spawned by
       enemy.update()" -- exactly so update() owns the &mut VisualEffects
       borrow rather than take_damage() pulling it transitively.
+      The Attack-state hitscan added in the 2026-05-13 combat slice
+      reuses the same borrow chain: enemy_logic::update already takes
+      &mut Player and uses player_state::take_damage as the call site
+      for hitscan-on-player damage application, and &mut VisualEffects
+      (for blood splat at the player on hit, wall puff on miss-into-
+      wall). No new borrow is introduced — only a new consumer of the
+      existing borrows. Resolution stays A.
+
+  - call_site: "game_loop drop-spawn scan (specs/60 § Enemy Ammo Drops)"
+    resolution: B
+    rationale: |
+      The ammo-drop spawn is NOT enemy_logic's responsibility because
+      enemy_logic::update has only &Level, not &mut Level::pickups —
+      pushing a Pickup requires the &mut Vec<Pickup> borrow. Rather
+      than widening update()'s borrow graph (which would force
+      weapon_system::fire's &Level to also become &mut Level on the
+      take_damage transitive path), game_loop hosts a small scan
+      after the enemy update + weapon fire steps in
+      frame_update_order. enemy_logic::take_damage flips
+      Enemy.ammo_drop_spawned = false (the field is initialized
+      false and stays false through state transitions); game_loop's
+      scan reads !enemy.alive AND !enemy.ammo_drop_spawned to decide
+      whether to push, then flips to true. This is the canonical
+      Resolution-B shape: the per-frame hook returns data
+      (Enemy.ammo_drop_spawned still false after death) that the
+      orchestration layer (game_loop) reads and acts on.
 
   - call_site: "enemy_logic::take_damage"
     resolution: A
@@ -369,6 +396,9 @@ coder_degrees_of_freedom:
   - "Whether the ammo-opportunism two-segment path is computed as one concatenated BFS or as two replans (player→pickup, then pickup→target after consumption). Both meet the spec; option (b) reuses single-target BFS without modification."
   - "Choice of slide algorithm in player_state and enemy_logic (axis-aligned per spec/21; the per-axis order and the integer-vs-float of the radius check are Coder-internal)."
   - "Whether VisualEffect lifetime decay uses retain() or a manual swap_remove loop -- both meet the spec."
+  - "Enemy LoS helper for the Attack-state gate (`enemy_has_los(from, to, level) -> bool`) shape. Coder may keep it module-private to enemy_logic, or extract a shared `level_data::has_los` helper that both enemy_logic and autopilot's `has_line_of_sight` import. Either shape meets the contract; the tile-grid ray-cast at TRACE_STEP samples (or the closed-form 2D DDA equivalent) is what is pinned in spec, not the function's home."
+  - "Whether the trooper's hitscan ray-march reuses TRACE_STEP imported from weapon_system or duplicates the 0.1-tile literal. Both are acceptable; weapon_system's TRACE_STEP is already public for the player-fire path, so importing it does NOT widen weapon_system's API surface."
+  - "Game_loop's drop-spawn scan implementation shape (single iter_mut + push, two-pass collect-then-push to avoid split-borrow ergonomics, drain_filter pattern, etc.). The contract pins the behavior (one Pickup pushed per dead trooper at the death position, gated by ammo_drop_spawned) and not the loop shape."
 
 # -----------------------------------------------------------------------------
 # Things intentionally NOT pinned (and flagged so Reconciler doesn't double-look)
@@ -399,10 +429,30 @@ spec_conflicts_resolved:
       (deferred) constants. Spec/25 takes precedence per CLAUDE.md
       "Specs are the source of truth".
     resolution: |
-      Coders implement the "Implemented" rows of specs/25 only. The
-      "Target (from knowledge, not yet implemented)" rows are carried
-      in spec/25 explicitly so they remain Reconciler-visible without
-      being implemented this run. Triangular spread IS implemented
-      (rand-rand) per the contract for weapon_system::fire above --
-      this is a partial uplift from the pre-existing approximation
-      and is consistent with specs/25 first-shot accuracy semantics.
+      Coders implement the "Implemented" rows of specs/25 only.
+      Triangular spread IS implemented (rand-rand) per the contract
+      for weapon_system::fire and enemy_logic::update Attack arm.
+      The 2026-05-13 combat slice promoted the trooper's ranged
+      hitscan, line-of-sight detection, Attack state, and ammo-clip
+      drop from the prior `### Target` table to `### Implemented` —
+      the table itself was retired and replaced by `### Deferred from
+      knowledge` (specs/25 § Enemy), which lists only the rows the
+      prototype intentionally does NOT ship (distance probability
+      check, no-double-attack direction switch, 8-directional grid
+      pathing, idle-scan animation, target threshold, sound
+      propagation, gib threshold, half-clip "dropped" flag, etc.).
+      ir/game_ir.yaml's `simplifications` block was refreshed in the
+      same combat-slice commit: the prior three entries
+      (`enemy_attack_is_contact_not_hitscan`,
+      `enemy_ai_simplified_no_attack_state`,
+      `enemy_detection_is_immediate_no_los`) are removed (kept as
+      `# Removed:` comments for traceability) and replaced by the
+      four narrower deferred entries that match
+      specs/25 § Enemy § Deferred from knowledge
+      (`enemy_ranged_fire_no_distance_probability_check`,
+      `enemy_no_double_attack_direction_switch_omitted`,
+      `enemy_movement_smooth_slide_not_8_directional_grid`,
+      `enemy_drop_full_amount_no_dropped_flag`). Specs precedence
+      still applies — the IR file's `simplifications` list is now a
+      consistent shorthand of spec/25's deferred-from-knowledge
+      table, not an alternative source.

--- a/ir/contracts/enemy_logic.yaml
+++ b/ir/contracts/enemy_logic.yaml
@@ -11,9 +11,18 @@ public_types:
       pub enum EnemyState {
           Idle,    // pre-reaction-delay
           Chase,   // moving toward player
+          Attack,  // stationary windup → fire (hitscan) → cooldown
           Pain,    // briefly stunned
           Dead,    // health <= 0; corpse fade in progress or done
       }
+    notes: |
+      `Attack` was added in the 2026-05-13 combat slice (specs/25 §
+      Enemy ranged hitscan promotion). The trooper does not move while
+      in Attack; per-frame movement only runs in the Chase arm. Pain
+      may interrupt Attack at any time (see take_damage below); on
+      Pain expiry the trooper returns to Chase, not Attack — knowledge
+      `enemy_types.md § Chase Behavior` says the reaction routine
+      re-evaluates whether to fire on the next Chase frame.
   - name: Enemy
     definition: |
       pub struct Enemy {
@@ -23,28 +32,44 @@ public_types:
           pub state: EnemyState,
           pub time_in_state: f32,    // seconds since entering current state
           pub pain_flash_remaining: f32,  // 0.0 = no flash; counts down each tick
-          pub time_since_attack: f32,     // seconds since last contact hit (cooldown gate)
+          pub time_since_attack: f32,     // seconds since last Attack-state entry (cooldown gate)
+          pub attack_fired_this_sequence: bool,  // set true inside Attack once the hitscan fires; reset to false on Attack→Chase transition (or Attack-state re-entry)
           pub death_fade_remaining: f32,  // > 0 while in death fade; 0 when corpse should spawn
           pub corpse_spawned: bool,       // true once spawn_enemy_corpse has fired
+          pub ammo_drop_spawned: bool,    // true once game_loop has pushed the death-time ammo Pickup; gates one-per-trooper drop (specs/60 § Enemy Ammo Drops)
       }
+    notes: |
+      `attack_fired_this_sequence` is the in-state latch that
+      guarantees exactly one hitscan per Attack sequence even though
+      `update()` may tick many times during the sequence. `ammo_drop_spawned`
+      is the equivalent latch for the death-time drop spawn — game_loop
+      reads it in the frame_update_order drop scan and flips it true
+      after pushing the Pickup.
 public_constants:
-  - { name: ENEMY_MAX_HEALTH,         type: i32, value: "20",     source: "specs/25 § Enemy" }
-  - { name: ENEMY_SPEED_TILES_PER_SEC,type: f32, value: "2.0",    source: "specs/25 § Enemy" }
-  - { name: ENEMY_RADIUS_TILES,       type: f32, value: "0.375",  source: "specs/25 § Visual (12 px / 32 px) -- used for hit detection by weapon_system" }
-  - { name: ENEMY_REACTION_DELAY,     type: f32, value: "0.23",   source: "specs/25 § Enemy" }
-  - { name: ENEMY_ATTACK_COOLDOWN,    type: f32, value: "0.54",   source: "specs/25 § Enemy" }
-  - { name: ENEMY_PAIN_DURATION,      type: f32, value: "0.17",   source: "specs/25 § Enemy" }
-  - { name: ENEMY_PAIN_CHANCE,        type: f32, value: "0.78",   source: "specs/25 § Enemy (200/255)" }
-  - { name: ENEMY_CONTACT_RANGE_TILES,type: f32, value: "0.8125", source: "specs/25 § Enemy (player 14 + enemy 12 px = 26 px / 32 px)" }
-  - { name: ENEMY_ATTACK_DAMAGE_VALUES, type: "[i32; 5]", value: "[3, 6, 9, 12, 15]", source: "specs/25 § Enemy (formula (rand(0..4)+1)*3)" }
+  - { name: ENEMY_MAX_HEALTH,         type: i32, value: "20",     source: "specs/25 § Enemy (knowledge-backed: knowledge/combat_balance.md § Enemy Health Tiers)" }
+  - { name: ENEMY_SPEED_TILES_PER_SEC,type: f32, value: "2.0",    source: "specs/25 § Enemy (Generation default — knowledge-derived but rescaled to tile units)" }
+  - { name: ENEMY_RADIUS_TILES,       type: f32, value: "0.375",  source: "specs/25 § Visual (12 px / 32 px) -- used for hit detection by weapon_system and by the trooper's chase-movement collision" }
+  - { name: ENEMY_REACTION_DELAY,     type: f32, value: "0.23",   source: "specs/25 § Enemy (knowledge-backed: knowledge/enemy_types.md § Detection and Alerting, 8 ticks @ 35Hz)" }
+  - { name: ENEMY_PAIN_DURATION,      type: f32, value: "0.17",   source: "specs/25 § Enemy (knowledge-backed: knowledge/enemy_types.md § State Machine, 6 ticks @ 35Hz)" }
+  - { name: ENEMY_PAIN_CHANCE,        type: f32, value: "0.78",   source: "specs/25 § Enemy (knowledge-backed: knowledge/enemy_types.md § Pain System, 200/256)" }
+  - { name: ENEMY_CONTACT_RANGE_TILES,type: f32, value: "0.8125", source: "specs/25 § Enemy (player 14 + enemy 12 px = 26 px / 32 px). Retained as a derived constant — referenced by autopilot kite buffer (BOT_KITE_RANGE) and by the RangedStandoff demo-level rationale (specs/15). The Attack state replaces contact damage as the trooper's primary harm vector; specs/25 § Enemy § Deferred from knowledge tracks the melee-contact deferral." }
+  - { name: ENEMY_ATTACK_RANGE_TILES, type: f32, value: "64.0",   source: "specs/25 § Enemy (knowledge-backed: knowledge/combat_balance.md § Range and Hit Detection, 2048 world units / 32 px per tile)" }
+  - { name: ENEMY_ATTACK_SPREAD_RAD,  type: f32, value: "0.3839", source: "specs/25 § Enemy (knowledge-backed: knowledge/combat_balance.md § Accuracy and Spread, 22° each side; 22 * π / 180 ≈ 0.3839)" }
+  - { name: ENEMY_ATTACK_SEQUENCE_SEC,type: f32, value: "0.74",   source: "specs/25 § Enemy (knowledge-backed: knowledge/enemy_types.md § State Machine, 26 ticks @ 35Hz). Replaces the prior ENEMY_ATTACK_COOLDOWN constant — the contact-damage cooldown is retired; this is the full Attack-state duration (wind-up + fire + cooldown sub-phases)." }
+  - { name: ENEMY_ATTACK_WINDUP_SEC,  type: f32, value: "0.286",  source: "specs/25 § Enemy (knowledge-backed: knowledge/enemy_types.md § State Machine, 10-tick wind-up @ 35Hz). Time-in-Attack-state at which the hitscan trace fires; before this elapses the trooper is facing the target but has not yet released the shot." }
+  - { name: ENEMY_ATTACK_DAMAGE_VALUES, type: "[i32; 5]", value: "[3, 6, 9, 12, 15]", source: "specs/25 § Enemy (knowledge-backed: knowledge/combat_balance.md § Hitscan Damage Formula, `((rnd%5) + 1) * 3`)" }
 public_methods:
   - signature: "pub fn new(spawn: Vec2) -> Enemy"
     notes: |
       health = ENEMY_MAX_HEALTH, alive = true, state = Idle,
       time_in_state = 0.0, pain_flash_remaining = 0.0,
-      time_since_attack = ENEMY_ATTACK_COOLDOWN (so the *first*
-      attack can fire immediately after the reaction delay),
-      death_fade_remaining = 0.0, corpse_spawned = false.
+      time_since_attack = ENEMY_ATTACK_SEQUENCE_SEC (so the *first*
+      attack can fire immediately after the reaction delay — the
+      cooldown gate `time_since_attack >= ENEMY_ATTACK_SEQUENCE_SEC`
+      is satisfied at spawn),
+      attack_fired_this_sequence = false,
+      death_fade_remaining = 0.0, corpse_spawned = false,
+      ammo_drop_spawned = false.
   - signature: |
       pub fn update(
           enemy: &mut Enemy,
@@ -65,21 +90,86 @@ public_methods:
              Chase:
                - if !player.alive: do nothing.
                - dx = player.pos - enemy.pos; dist = dx.length().
-               - if dist <= ENEMY_CONTACT_RANGE_TILES and
-                 time_since_attack >= ENEMY_ATTACK_COOLDOWN:
-                   dmg = ENEMY_ATTACK_DAMAGE_VALUES[rand_idx];
-                   player_state::take_damage(player, dmg);
-                   time_since_attack = 0.0;
-                   (no console message required; specs/20 mentions
-                    existing stdout messages but flagging their fate
-                    is a Coder decision per specs/40 line 156).
+               - Ranged attack gate (specs/25 § Enemy Implemented,
+                 knowledge/enemy_types.md § Chase Behavior + § Ranged
+                 Attack Probability Check minus the deferred distance
+                 probability):
+                   if dist <= ENEMY_ATTACK_RANGE_TILES
+                      AND enemy_has_los(enemy.pos, player.pos, level)
+                      AND time_since_attack >= ENEMY_ATTACK_SEQUENCE_SEC:
+                     enemy.state = Attack;
+                     enemy.time_in_state = 0.0;
+                     enemy.time_since_attack = 0.0;
+                     enemy.attack_fired_this_sequence = false;
+                     // snap facing toward player implicitly — the
+                     // hitscan in Attack uses angle_to(player.pos) at
+                     // the moment of fire, so an explicit facing
+                     // field on Enemy is not required.
+                     return;                       // do not move this tick
                - else: move toward player at
                    ENEMY_SPEED_TILES_PER_SEC * dt, blocked by
                    level::is_wall (use axis-aligned slide identical
                    to player_state::apply_input).
+             Attack:
+               - // Stationary; no movement this tick.
+               - if !enemy.attack_fired_this_sequence
+                    AND enemy.time_in_state >= ENEMY_ATTACK_WINDUP_SEC:
+                   // Fire the hitscan trace.
+                   let aim = angle_to(player.pos, enemy.pos);
+                   let spread = (rand_f32() - rand_f32())
+                                 * ENEMY_ATTACK_SPREAD_RAD;
+                   let aim_angle = aim + spread;
+                   let damage_idx = (rand_u32() % 5) as usize;
+                   let dmg = ENEMY_ATTACK_DAMAGE_VALUES[damage_idx];
+                   // Ray-march from enemy.pos along aim_angle up to
+                   // ENEMY_ATTACK_RANGE_TILES in TRACE_STEP-sized
+                   // steps (TRACE_STEP from weapon_system; Coder may
+                   // import or duplicate the 0.1-tile literal —
+                   // either is acceptable, see coder_degrees_of_freedom).
+                   //   If a step lands within PLAYER_RADIUS_TILES of
+                   //   player.pos (and the player is alive): call
+                   //   player_state::take_damage(player, dmg),
+                   //   visual_effects::spawn_blood_splat(fx, player.pos),
+                   //   stop the ray.
+                   //   Else if level::is_wall at the step: call
+                   //   visual_effects::spawn_wall_puff(fx, step_pos),
+                   //   stop the ray.
+                   //   Else if range exceeded: stop the ray. No impact
+                   //   effect (specs/40 § Impact Effect Rules: "a trace
+                   //   that hits nothing produces no impact effect").
+                   // Note: the trooper's hitscan does NOT spawn a
+                   //   muzzle_flash or tracer in this slice — the
+                   //   visual-feedback constraints in the task scope
+                   //   say "Do NOT invent new visual effects for enemy
+                   //   fire. Reuse existing entries from visual_effects
+                   //   if knowledge backs them." The existing
+                   //   muzzle_flash and tracer effects are player-only
+                   //   in specs/40; reusing them for enemy fire would
+                   //   change their semantic (currently "player shot
+                   //   fired"). Adding distinct enemy-muzzle / enemy-
+                   //   tracer effects is parked as a follow-up
+                   //   (specs/40 § Deferred — Per-weapon puff variants
+                   //   covers the structural form). Wall puffs and
+                   //   blood splats are kind-agnostic in specs/40 so
+                   //   they reuse cleanly.
+                   enemy.attack_fired_this_sequence = true;
+               - if enemy.time_in_state >= ENEMY_ATTACK_SEQUENCE_SEC:
+                   enemy.state = Chase;
+                   enemy.time_in_state = 0.0;
+                   enemy.attack_fired_this_sequence = false;
+                   // time_since_attack continues to count from the
+                   // Attack-state entry — Chase's gate above checks
+                   // time_since_attack >= ENEMY_ATTACK_SEQUENCE_SEC,
+                   // so the trooper can re-enter Attack the next
+                   // tick if LoS and range still hold (the cooldown
+                   // is the sequence duration itself, exactly as the
+                   // reference's no-double-attack flag enforces).
              Pain:
                - if time_in_state >= ENEMY_PAIN_DURATION:
                    transition to Chase (reset time_in_state = 0).
+                   attack_fired_this_sequence stays as-is — it is
+                   irrelevant outside Attack, and will be reset on
+                   the next Attack entry.
              Dead:
                - if !corpse_spawned and death_fade_remaining > 0:
                    death_fade_remaining = (death_fade_remaining
@@ -92,6 +182,24 @@ public_methods:
       call it. update() is the per-frame AI hook, so spec/80 §
       API Surface permits direct &mut Player and &mut VisualEffects
       (resolution A).
+
+      RNG: enemy_logic uses the module-private RNG state seeded from
+      ENEMY_RNG_SEED (specs/25 § RNG Seeds). Coder may keep the RNG
+      on each Enemy (consistent with the prior contract notes) or
+      module-private — both shapes meet specs/35 § Determinism since
+      the seed is fixed. The Attack hitscan introduces two new RNG
+      consumers per attack (spread + damage index); both consume
+      from the same stream as the existing pain-check RNG.
+
+      LoS helper `enemy_has_los(from: Vec2, to: Vec2, level: &Level) -> bool`
+      is module-private (Coder degree of freedom). Tile-grid ray-cast
+      at TRACE_STEP-sized samples; returns false on first sample
+      inside Tile::Wall, else true. Closed-form 2D DDA is allowed
+      in lieu of stepping. autopilot's `has_line_of_sight` helper
+      already implements the same algorithm (Coder may extract a
+      shared `level_data::has_los` if both call sites benefit; spec
+      treats this as Coder discretion — see
+      coder_degrees_of_freedom in _shared.yaml).
   - signature: |
       pub fn take_damage(
           enemy: &mut Enemy,
@@ -110,10 +218,20 @@ public_methods:
              enemy.death_fade_remaining = ENEMY_DEATH_FADE_DURATION;
              fx.spawn_enemy_death_fade(enemy.pos);
              // corpse spawns later in update() per spec/40 line 100.
+             // The death-time ammo drop is handled by game_loop's
+             // drop-scan step in frame_update_order (specs/60 §
+             // Enemy Ammo Drops); take_damage does NOT push to
+             // level.pickups because it does not hold the &mut Level
+             // borrow. The Enemy.ammo_drop_spawned flag stays false
+             // here and is flipped by the drop-scan after this tick.
         4. else if rand_f32() < ENEMY_PAIN_CHANCE:
              enemy.state = EnemyState::Pain;
              enemy.time_in_state = 0.0;
              enemy.pain_flash_remaining = ENEMY_PAIN_FLASH_DURATION;
+             // Pain interrupts Attack at any point, including mid-
+             // sequence after the hitscan has already fired. The
+             // attack_fired_this_sequence flag stays as-is — it is
+             // overwritten on the next Attack-state entry.
              // spec/40 § Enemy Pain Flash: re-arm flash on every
              // *successful* pain check, not on every hit.
       take_damage is invoked from inside weapon_system::fire which
@@ -121,12 +239,32 @@ public_methods:
       is therefore part of the combat tick borrow graph.
       Spec/80 exception A applies transitively.
 cross_module_borrows:
-  - "&mut Player (apply contact damage in update)"
-  - "&Level (immutable read in update for collision)"
-  - "&mut VisualEffects (spawn pain flash, death fade, corpse) -- spec/80 exception A"
+  - "&mut Player (apply ranged hitscan damage in update's Attack arm)"
+  - "&Level (immutable read in update for collision + LoS + Attack ray-march)"
+  - "&mut VisualEffects (spawn pain flash, death fade, corpse, blood splat on enemy ranged hit, wall puff when enemy hitscan misses player into wall) -- spec/80 exception A"
 notes: |
   ENEMY_PAIN_FLASH_DURATION is imported from visual_effects (it is
   a visual constant; the enemy struct just holds the current
   remaining timer). Random helper -- enemy may use a tiny LCG;
   Coder can share a module-private RNG with weapon_system or
   duplicate. Coder degree of freedom.
+
+  The Attack state's hitscan reuses player_state::take_damage to
+  apply damage to the player — same entry point as the prior
+  contact-damage path. The damage tint accumulator
+  (Player.damage_count) is therefore driven identically whether
+  the trooper hits via contact (legacy) or hitscan (this slice's
+  Implemented path). Visual_effects::spawn_blood_splat is reused
+  for the impact point at player.pos when the trooper's trace
+  lands on the player (kind-agnostic in specs/40 § Impact Effects
+  — same effect as a player-fired weapon impact on an enemy);
+  visual_effects::spawn_wall_puff is reused for the trooper's
+  miss-into-wall case.
+
+  Per the combat-slice task scope: "Do NOT change pistol or player
+  tuning; weapon_system edits are limited to the trooper hitscan
+  path. Pistol behavior must remain identical." The hitscan
+  implementation lives entirely inside enemy_logic::update's
+  Attack arm — weapon_system::fire is unchanged. A shared
+  hitscan-helper extraction would be a follow-up slice (see
+  weapon_system contract notes).

--- a/ir/contracts/level_generator.yaml
+++ b/ir/contracts/level_generator.yaml
@@ -12,15 +12,17 @@ public_types:
       pub enum DemoLevelKind {
           LocalChaseObstacle,
           KiteMelee,
+          RangedStandoff,
       }
     notes: |
       Public because autopilot::Scenario.level holds
       Option<DemoLevelKind> (specs/15 § Scenario YAML Extension), so
       serde_yaml can deserialize the YAML name directly into the
       enum. `rename_all = "snake_case"` maps `LocalChaseObstacle`
-      -> `local_chase_obstacle` and `KiteMelee` -> `kite_melee`
-      for YAML readability. Adding a new demo level: add one variant
-      here and one match arm in build() below; nothing else changes.
+      -> `local_chase_obstacle`, `KiteMelee` -> `kite_melee`, and
+      `RangedStandoff` -> `ranged_standoff` for YAML readability.
+      Adding a new demo level: add one variant here and one match arm
+      in build() below; nothing else changes.
 public_constants: []
 public_methods:
   - signature: "pub fn build(kind: DemoLevelKind) -> Level"
@@ -34,6 +36,7 @@ public_methods:
         match kind {
             DemoLevelKind::LocalChaseObstacle => build_local_chase_obstacle(),
             DemoLevelKind::KiteMelee          => build_kite_melee(),
+            DemoLevelKind::RangedStandoff     => build_ranged_standoff(),
         }
       where each helper is a private function returning the Level
       layout pinned in specs/15 § <variant>.
@@ -70,6 +73,27 @@ public_methods:
       and outside ENEMY_CONTACT_RANGE_TILES (0.8125, specs/25 §
       Enemy) so the bot has buffer to back-pedal before contact
       damage starts.
+  - signature: "fn build_ranged_standoff() -> Level"
+    notes: |
+      Module-private. Builds the RangedStandoff layout from specs/15
+      § RangedStandoff. Concretely:
+        width = GRID_WIDTH (20); height = GRID_HEIGHT (15);
+        tiles[y][x] = Wall iff (x == 0 || x == 19 || y == 0 || y == 14)
+                      else Floor;
+        player_spawn = Vec2::new(4.5, 7.5);
+        enemy_spawns = vec![Vec2::new(12.5, 7.5)];
+        exit         = Vec2::new(1.5, 1.5);
+        pickups      = vec![];   // no pickups
+      No interior walls. Distance from player_spawn to the lone
+      enemy_spawn is 8.0 tiles -- well outside BOT_KITE_RANGE (2.0)
+      so the bot does not enter kite mode at frame 0, and ~10x
+      ENEMY_CONTACT_RANGE_TILES (0.8125) so the trooper cannot
+      contact-damage the player from spawn. The trooper has direct
+      LoS along y = 7.5 (open arena), so its Attack-state hitscan
+      is the only source of player damage during the bot's `wait:`
+      objective in tests/combat/trooper_ranged_hits.yaml. Within
+      ENEMY_ATTACK_RANGE_TILES (64.0) so the trooper can fire from
+      spawn without range-gating.
 cross_module_borrows: []
 notes: |
   Consumed by main.rs at startup (one call per --autopilot launch

--- a/ir/contracts/player_state.yaml
+++ b/ir/contracts/player_state.yaml
@@ -95,7 +95,9 @@ public_methods:
       game_loop and matches the orchestration style used elsewhere.
   - signature: "pub fn take_damage(player: &mut Player, amount: i32)"
     notes: |
-      Used by enemy_logic::update on contact damage. Mutates only the
+      Used by enemy_logic::update's Attack-state hitscan when the
+      trooper's trace lands on the player (specs/20 § Enemy ranged
+      attack form, specs/25 § Enemy Implemented). Mutates only the
       player struct (no &mut VisualEffects param -- spec/80 § API
       Surface forbids it on non-orchestration methods). Behavior:
         health -= amount;

--- a/ir/game_ir.yaml
+++ b/ir/game_ir.yaml
@@ -59,11 +59,15 @@ rendering:
   complexity: minimal
 
 simplifications:
-  - enemy_attack_is_contact_not_hitscan
-  - enemy_ai_simplified_no_attack_state
-  - enemy_detection_is_immediate_no_los
+  # Removed: enemy_attack_is_contact_not_hitscan — replaced by ranged hitscan in the 2026-05-13 combat slice (specs/25 § Enemy Implemented; specs/20 § Enemy state machine)
+  # Removed: enemy_ai_simplified_no_attack_state — Attack state added in the 2026-05-13 combat slice (ir/contracts/enemy_logic.yaml § EnemyState)
+  # Removed: enemy_detection_is_immediate_no_los — LoS-gated detection added in the 2026-05-13 combat slice (specs/25 § Enemy Implemented; specs/20 § Enemy)
   # Removed: weapon_spread_approximated_not_triangular — triangular spread (rand-rand) is now implemented
   # Removed: player_movement_direct_not_momentum — thrust+friction momentum model is now implemented
+  - enemy_ranged_fire_no_distance_probability_check  # specs/25 § Enemy § Deferred from knowledge — knowledge has a `random(0..255) < distance_with_modifiers` gate that suppresses some firings at long range; the prototype always fires when LoS, range, and cooldown all hold
+  - enemy_no_double_attack_direction_switch_omitted   # specs/25 § Enemy § Deferred from knowledge — direction-switch on post-attack is not implemented (the cooldown gate `time_since_attack >= ENEMY_ATTACK_SEQUENCE_SEC` provides the no-double-attack timing, but the direction switch is cosmetic)
+  - enemy_movement_smooth_slide_not_8_directional_grid # specs/25 § Enemy § Deferred from knowledge — smooth axis-aligned slide instead of the reference's 8-direction grid
+  - enemy_drop_full_amount_no_dropped_flag            # specs/60 § Enemy Ammo Drops + specs/25 § Enemy § Deferred from knowledge — single-amount ammo pickup, half-clip "dropped" flag deferred
 
 generation:
   mode: incremental_preferred

--- a/specs/15_level_generator.md
+++ b/specs/15_level_generator.md
@@ -36,6 +36,7 @@ The generator owns a small `DemoLevelKind` enum. Each variant maps to one builde
 |---------|-----------|---------|-------------|
 | `LocalChaseObstacle` | `local_chase_obstacle` | Demonstrates obstacle-aware enemy chase: one wall between player and enemy, valid path around. | yes |
 | `KiteMelee` | `kite_melee` | Demonstrates the bot's kite policy: enemy spawns within `BOT_KITE_RANGE`, bot must back-pedal while firing (specs/30 § Bot Behavior). | yes |
+| `RangedStandoff` | `ranged_standoff` | Demonstrates the basic trooper's ranged hitscan attack: open arena, enemy spawned ~8 tiles east of the player so the trooper can fire from outside `ENEMY_CONTACT_RANGE_TILES` while the bot waits stationary (specs/20 § Enemy, specs/25 § Enemy ranged hitscan rows). | yes |
 
 ### LocalChaseObstacle
 
@@ -79,11 +80,31 @@ Either gap is wide enough for both the player (radius `0.4375` tile per `PLAYER_
 | Entity | Position | Rationale |
 |--------|----------|-----------|
 | Player spawn | `(4.5, 7.5)` | West side, vertically centered. Player faces `+X` (default heading) so the enemy lies directly along the firing line. |
-| Enemy spawn | `(6.0, 7.5)` | 1.5 tiles east of the player. Inside `BOT_KITE_RANGE` (2.0) so the bot enters kite mode on frame 1, but outside `ENEMY_CONTACT_RANGE_TILES` (0.8125) so the bot can back-pedal one or two frames before contact damage starts. |
+| Enemy spawn | `(6.0, 7.5)` | 1.5 tiles east of the player. Inside `BOT_KITE_RANGE` (2.0) so the bot enters kite mode on frame 1, but outside `ENEMY_CONTACT_RANGE_TILES` (0.8125) so kite-mode visual layout is preserved (the discs do not visibly overlap at spawn). With the 2026-05-13 combat slice replacing contact damage with the trooper's ranged hitscan attack, the kite buffer no longer protects against contact damage (which is retired) — it now protects against the trooper's near-melee hitscan, where the spread cone (±22°) at 1.5 tiles distance covers nearly the full forward arc, so a trooper that completes its 0.74s Attack sequence almost always hits. The bot must back-pedal AND fire fast enough to kill the trooper before the first Attack-state hitscan releases (the trooper's high pain-chance helps — sustained pistol fire tends to pain-lock the trooper before its windup-elapsed fire latch trips). |
 | Exit | `(1.5, 1.5)` | Far top-left corner; the `kill: enemy` objective never directs the bot toward the exit, so the win-condition check is not triggered. |
 | Pickups | (none) | Empty `Vec<Pickup>`. Pickups would distract from the kite visualization and would also let the bot recover health during the test, which would dilute the `player.health > 80` assertion. |
 
-**Behavior to observe.** The bot starts inside kite range with the enemy directly east. On frame 1 the bot fires (LoS clear, `dist = 1.5 < BOT_FIRE_MAX_RANGE`, roughly facing) and emits `forward = -1.0` (kite mode). The bot retreats westward; the enemy chases at 2.0 tiles/sec. The pistol kills the enemy in 2–4 shots (mean 10 dmg vs 20 HP); during those ~1.0–2.0 seconds the bot may take one or two contact hits if the enemy briefly closes inside contact range, but `player.health > 80` should hold across the run because (a) first-shot accuracy lands the first hit, (b) 78% pain chance interrupts the enemy's chase frequently, and (c) the bot's max speed exceeds the enemy's 2.0 tiles/sec.
+**Behavior to observe.** The bot starts inside kite range with the enemy directly east. On frame 1 the bot fires (LoS clear, `dist = 1.5 < BOT_FIRE_MAX_RANGE`, roughly facing) and emits `forward = -1.0` (kite mode). The bot retreats westward; the enemy chases at 2.0 tiles/sec. The pistol kills the enemy in 2–4 shots (mean 10 dmg vs 20 HP); during those ~1.0–2.0 seconds the bot may take 0–1 ranged hitscan hits from the trooper if a Pain-state interruption fails to stun-lock the trooper before its Attack windup elapses — `player.health > 80` should hold across the run because (a) first-shot accuracy lands the first hit, (b) 78% pain chance interrupts the trooper's Attack sequence frequently before the windup elapses, (c) the bot's max speed exceeds the enemy's 2.0 tiles/sec, and (d) even a successful trooper hitscan deals 3–15 (mean 9) damage — well below the 20-HP buffer. With the 2026-05-13 combat slice's contact-damage retirement, the trooper's ONLY harm vector here is the ranged hitscan; the assertion's robustness depends on pain-locking the trooper rather than out-running contact range.
+
+### RangedStandoff
+
+**Purpose.** A short scenario that exercises the basic trooper's ranged hitscan attack (specs/20 § Enemy, specs/25 § Enemy). The trooper spawns 8 tiles east of the player in an open arena. The bot's first objective is `wait: <frames>` so the player stands still while the trooper enters its Attack state and fires hitscan rounds from well outside `ENEMY_CONTACT_RANGE_TILES`. Subsequent objectives close the engagement so the scenario completes deterministically. The level is otherwise empty so the only damage source the assertion can attribute is the trooper's hitscan.
+
+**Layout** (20 × 15 grid — same dimensions and `TILE_SIZE` as the default level):
+
+- All edges are walls (border): `x = 0`, `x = 19`, `y = 0`, `y = 14`.
+- No interior walls. The room is one open rectangle.
+
+**Spawns:**
+
+| Entity | Position | Rationale |
+|--------|----------|-----------|
+| Player spawn | `(4.5, 7.5)` | West side, vertically centered. Player faces `+X` (default heading) so the enemy lies directly along the firing line — trooper LoS to player and bot facing toward target both hold from frame 0. |
+| Enemy spawn | `(12.5, 7.5)` | 8.0 tiles east of the player along the same horizontal line. Outside `BOT_KITE_RANGE` (2.0) so kite mode does not activate immediately. Outside `BOT_FIRE_MAX_RANGE`-minus-margin so the bot also takes a moment to engage. Inside `ENEMY_ATTACK_RANGE_TILES` (64.0) so the trooper can fire from spawn. Outside `ENEMY_CONTACT_RANGE_TILES` (0.8125) by ~10× so contact damage is impossible during the scripted wait window. |
+| Exit | `(1.5, 1.5)` | Far top-left corner; `kill: enemy` and `wait:` objectives never direct the bot toward the exit, so the win-condition check is not triggered. |
+| Pickups | (none) | Empty `Vec<Pickup>`. The dropped ammo clip from the trooper's death (specs/60 § Enemy Ammo Drops) is the only pickup that exists during the run; the level seeds none so the assertion can attribute any pre-kill damage exclusively to the trooper's hitscan. |
+
+**Behavior to observe.** During the `wait:` objective the bot stands still and the trooper starts its state machine: Idle (reaction delay) → Chase (immediate, since LoS holds) → Attack (windup, fire, cooldown). Each Attack cycle resolves a hitscan trace at the player with `(rand_a − rand_b) * ENEMY_ATTACK_SPREAD_RAD` triangular spread. With the trooper at 4–8 tiles distance throughout the wait window (the enemy moves ~2.0 tiles/sec while in Chase between attacks), the player remains far outside contact range so any HP loss is provably from ranged hitscan. After the wait completes, `kill: enemy` engages: the bot turns toward the trooper, fires the pistol from path-follow distance, and the trooper dies in 2–4 shots (specs/25 § Damage Randomization). The dropped ammo clip lands at the trooper's death position (specs/60 § Enemy Ammo Drops); it is irrelevant to the assertions but exercises the death-time spawn hook.
 
 ## Scenario YAML Extension
 
@@ -241,6 +262,7 @@ described in § PR Preview Integration.
 - Test fixture `tests/level/local_chase_obstacle.yaml` exists on disk and uses the `level: local_chase_obstacle` field plus the `approach: enemy` / `kill: enemy` objectives.
 - `KiteMelee` is exercised by `level_generator` unit tests (`test_kite_melee_*` in `src/level_generator.rs`) which cover dimensions, spawn placement, the open-arena layout, the no-pickup invariant, and the within-`BOT_KITE_RANGE` distance assertion.
 - Test fixture `tests/combat/kite_enemy.yaml` exists on disk and uses the `level: kite_melee` field, the `kill: enemy` objective, and the `player.health > 80` assertion. `autopilot::run_all_scenarios` exercises the kite policy end-to-end alongside the unit tests above.
+- Test fixture `tests/combat/trooper_ranged_hits.yaml` exists on disk and uses the `level: ranged_standoff` field, a `wait:` objective followed by `kill: enemy`, and the `player.health < 100` assertion to verify the trooper's ranged hitscan damages the player from outside `ENEMY_CONTACT_RANGE_TILES`. `autopilot::run_all_scenarios` exercises the ranged-attack pipeline end-to-end.
 - IR module `level_generator` is added to `ir/module_plan.yaml` (universal-sink rule applied: `main.depends_on` lists `level_generator`).
 - IR contract for `level_generator` and the autopilot / `game_loop` extensions live in `ir/contracts/level_generator.yaml`, `ir/contracts/autopilot.yaml`, and `ir/contracts/game_loop.yaml`.
 - `.github/workflows/pr.yml` and `.github/workflows/release.yml` record the demo GIF using `tests/level/local_chase_obstacle.yaml` as the canonical PR-preview scenario.

--- a/specs/20_gameplay_model.md
+++ b/specs/20_gameplay_model.md
@@ -67,45 +67,27 @@ One enemy archetype exists: a basic hitscan trooper (low HP, single hitscan atta
 
 #### Current Implementation
 
-The enemy currently uses a simplified AI:
-- Detects player immediately (no line-of-sight check)
-- Waits a reaction delay (0.23s) before first attack
-- Moves toward player using smooth vector movement
-- Deals contact damage (3-15 random) when within melee range
-- Enters pain state on hit (78% chance, 0.17s duration)
-- Dies at 0 HP
+The enemy uses an LoS-gated ranged AI:
+- Detects the player on the first Idle tick the LoS check passes (knowledge/enemy_types.md § Detection and Alerting). The 180° forward arc is omnidirectional in the prototype; sound propagation is not modeled.
+- Waits a reaction delay (`ENEMY_REACTION_DELAY = 0.23s`) before transitioning Idle → Chase. The first Attack-state entry can fire on the very next Chase tick because `time_since_attack` is initialized to `ENEMY_ATTACK_SEQUENCE_SEC` at spawn (the cooldown gate is satisfied from the start).
+- Moves toward the player while in Chase using smooth axis-aligned slide (the same code path as `player_state::apply_input`, not the reference's 8-direction grid — see `25_game_tuning.md § Enemy § Deferred from knowledge`).
+- In Chase, transitions to Attack iff (a) line of sight to the player is clear, (b) distance ≤ `ENEMY_ATTACK_RANGE_TILES = 64.0`, and (c) `time_since_attack >= ENEMY_ATTACK_SEQUENCE_SEC = 0.74`.
+- In Attack, stays stationary for `ENEMY_ATTACK_SEQUENCE_SEC` total. At `ENEMY_ATTACK_WINDUP_SEC = 0.286s` into the state, fires a single hitscan trace toward the player with `(rand_a − rand_b) * ENEMY_ATTACK_SPREAD_RAD` triangular spread (±22° max). Damage on hit is one of `ENEMY_ATTACK_DAMAGE_VALUES = [3, 6, 9, 12, 15]` (formula `(rand(0..5) + 1) * 3`). On player hit, spawns a blood splat at the player's position; on wall hit, spawns a wall puff at the trace endpoint; on out-of-range, no impact effect. After the sequence elapses, returns to Chase and may re-enter Attack on the next tick if conditions still hold.
+- Enters pain state on hit (78% chance per damage event, 0.17s duration). Pain interrupts Idle, Chase, or Attack and returns to Chase on expiry.
+- Dies at 0 HP; transitions to Dead state, plays the death-fade visual (`specs/40 § Enemy Death Visual`), and spawns one ammo-clip pickup at the death position via the `game_loop` drop-spawn step (`specs/60 § Enemy Ammo Drops`). The pickup is collectible by the player via the existing `game_loop` per-frame pickup check.
 
-AI states: Idle → Chase → Pain → Death (no separate Attack state).
-
-#### Target Behavior (from knowledge)
-
-The full AI from knowledge/enemy_types.md is significantly more complex. The following are extracted behaviors that are **not yet implemented** but documented for future generation:
-
-**Hitscan ranged attack**: Enemy should fire hitscan shots at range (up to 2048 map units) with +/- 22 degree spread, not contact damage. Attack sequence takes 0.74 seconds (wind-up, fire, cooldown).
-
-**Distance-based fire probability**: At close range, almost always fires. At long range, probability drops (~22% at max distance). If just hit, always retaliates immediately. No double attack (must take at least one chase step between shots).
-
-**Line-of-sight detection**: Enemy should only react when it can see the player. No distance limit — if LOS exists, enemy reacts.
-
-**8-directional grid movement**: Prefers diagonal paths, tries cardinal directions if blocked. Random 0-15 steps before re-evaluating direction. Never voluntarily reverses.
-
-**Idle scanning**: 0.57s scan cycle before detection. 180-degree forward arc.
-
-**Chase timing**: 0.91s per animation cycle (8 frames). Active sound chance 1.2% per frame.
-
-**Target persistence**: 2.86s threshold of stubborn pursuit after acquiring target.
-
-**Death drops**: Ammo clip on death. Gib death below -20 HP.
-
-**Full state machine**:
+**State machine** (ranged-attack form):
 ```
-Idle --[player detected]--> Chase
-Chase --[attack check passed]--> Attack
+Idle  --[reaction delay elapsed]--> Chase
+Chase --[LoS && range && cooldown]--> Attack
 Chase --[damaged, pain check passed]--> Pain
-Attack --[attack sequence complete]--> Chase
+Attack --[sequence complete]--> Chase
+Attack --[damaged, pain check passed]--> Pain
 Pain --[pain duration elapsed]--> Chase
-Any --[health <= 0]--> Death
+Any --[health <= 0]--> Dead
 ```
+
+Knowledge-documented behaviors that the prototype intentionally does NOT implement (distance-based ranged-fire probability gate, no-double-attack direction switch, 8-directional grid pathing, idle-scan animation, target threshold, sound propagation, gib threshold, half-clip "dropped" flag) are listed in `25_game_tuning.md § Enemy § Deferred from knowledge` so the Reconciler does not flag them as drift.
 
 ### Level
 The level must:
@@ -143,7 +125,7 @@ Concretely, this requires the loop-exit *decision* and the loop-exit *action* to
 - Player movement (forward/backward/strafe) with thrust+friction momentum model (see [`21_player_movement.md`](21_player_movement.md)).
 - World collision — player cannot walk through walls; axis-aligned wall sliding.
 - Combat — hitscan pistol: fire cycle, discrete damage (5/10/15), triangular spread, first-shot accuracy, pain/stagger system.
-- Enemy basic trooper — AI states Idle/Chase/Pain/Dead; contact damage; reaction delay before first attack; pain flash visual.
+- Enemy basic trooper — AI states Idle/Chase/Attack/Pain/Dead; LoS-gated ranged hitscan attack with windup/fire/cooldown sequence and ±22° triangular spread; reaction delay before first Attack-state entry; pain flash visual; one ammo-clip pickup dropped at the death position.
 - Level — walls, walkable space, player spawn, enemy spawn, exit objective.
 - HUD — health bar + digits + ammo pane (see [`50_hud.md`](50_hud.md)).
 - Pickups — health and ammo pickups; refused-at-cap rule; ammo gates firing (see [`60_pickups.md`](60_pickups.md)).
@@ -158,6 +140,7 @@ Concretely, this requires the loop-exit *decision* and the loop-exit *action* to
 
 - Multiple weapons (shotgun, chaingun, fist, super shotgun)
 - Projectile-based enemy attacks (fireball with travel time, dodging)
+- Distance-based ranged-fire probability gate, no-double-attack direction switch, 8-directional grid pathing, idle-scan animation, target threshold, sound propagation, gib threshold, half-clip "dropped" ammo flag — see [`25_game_tuning.md § Enemy § Deferred from knowledge`](25_game_tuning.md#deferred-from-knowledge) for the full list and per-row rationale.
 - Multiple enemy types (shotgun trooper, rapid-hitscan trooper, ranged-melee hybrid, melee-only beast, invisible melee-only beast, floating projectile mid-tier, kamikaze flyer, mid-tier melee+projectile boss, heavy melee+projectile boss, homing-missile boss, triple-projectile boss, rapid-plasma boss, area-attack boss with corpse-resurrect, rocket-launcher mega-boss, super-chaingun mega-boss)
 - Armor and damage reduction system
 - Full ammo economy (multiple categories, scarcity pressure, dropped-from-enemy pickups, backpack/cap expander)

--- a/specs/25_game_tuning.md
+++ b/specs/25_game_tuning.md
@@ -27,39 +27,44 @@ Existing rows below this point predate the convention and are kept verbatim — 
 
 | Constant | Value | Source |
 |----------|-------|--------|
-| Health | 20 | knowledge/combat_balance.md |
-| Speed | 2.0 units/sec | Adapted from reference (slower than player) |
-| Detection | Immediate (simplified) | Target: line of sight, no distance limit |
-| Reaction delay | 0.23 seconds | Time before first attack after spotting player |
-| Attack type | Contact damage | Target: hitscan at range |
-| Attack damage | 3, 6, 9, 12, or 15 per hit | Formula: `(random(0..4) + 1) * 3`, mean ~9 |
-| Attack cooldown | 0.54 seconds | Time between contact hits |
+| Health | 20 | knowledge/combat_balance.md § Enemy Health Tiers ("Basic hitscan trooper (low HP): 20 HP") |
+| Speed | 2.0 units/sec | Adapted from reference (slower than player). Knowledge `enemy_types.md § Movement System` reports the reference's per-step speed (8 units/move-tick, ~280 units/sec at 35 ticks/sec); 2.0 tiles/sec scales that down so the trooper is slower than the player's `MAX_SPEED` while still feeling threatening at our 20×15 tile world. Generation default — knowledge-derived but rescaled to the prototype's tile-unit speed model. |
+| Detection | Line of sight (no distance limit) | knowledge/enemy_types.md § Detection and Alerting ("Visual scan ... line of sight"), § Line of Sight ("ray trace ... checks for intercepting two-sided lines"). No sound propagation, no 180° forward arc, no reject table — the prototype does a tile-grid ray-cast from enemy to player and accepts any LoS hit. The "180° forward arc" and "sound propagation" rules are deferred (this section's § Deferred-from-knowledge). |
+| Reaction delay | 0.23 seconds | knowledge/enemy_types.md § Detection and Alerting ("reaction time of 8 ticks" at 35 ticks/sec) and § Chase Behavior ("reaction time counter ... will not attack while non-zero"). Time before the first Attack-state entry after the trooper spots the player. |
+| Attack type | Hitscan at range | knowledge/enemy_types.md § Basic Hitscan Attack ("instant hitscan trace, not a projectile"). Replaces the prior "contact damage" simplification (specs/25 reconcile pass). |
+| Attack damage | 3, 6, 9, 12, or 15 per hit | Formula: `(random(0..5) + 1) * 3`, mean ~9. knowledge/combat_balance.md § Hitscan Damage Formula ("Enemy hitscan (basic grunt): `((rnd%5) + 1) * 3` = 3-15 per shot"). |
+| Attack range | 64.0 tiles (= 2048 map units) | knowledge/combat_balance.md § Range and Hit Detection ("Hitscan maximum range (MISSILERANGE): 2048 world units"). At 32 px/tile (`TILE_SIZE`), 2048 / 32 = 64 tiles — same conversion as `PISTOL_RANGE_TILES` for the player. |
+| Attack spread | +/- 22 degrees max | knowledge/combat_balance.md § Accuracy and Spread ("Enemy basic grunt: shift = 20, max spread ~22 degrees each side"). Triangular distribution applied per shot via `(rand_a − rand_b) * ENEMY_ATTACK_SPREAD_RAD`. |
+| Attack sequence | 0.74 seconds | knowledge/enemy_types.md § State Machine ("Attack (Missile): 26 ticks (~0.74 seconds): 10-tick wind-up, 8-tick fire frame, 8-tick cooldown") at 35 ticks/sec. Total Attack-state duration; the trooper does not move while in Attack. After the sequence, transitions back to Chase. |
+| Attack windup | 0.286 seconds | knowledge/enemy_types.md § State Machine ("10-tick wind-up: face target") at 35 ticks/sec = 10 / 35 ≈ 0.286. Time from Attack-state entry until the hitscan trace fires; the trooper's facing snaps toward the player on entry. |
 | ENEMY_RADIUS_TILES | 0.375 | Derived from enemy visual radius 12 px / TILE_SIZE (32). Used for collision detection in `enemy_logic.rs` and implicitly by `ENEMY_CONTACT_RANGE_TILES`. Captured during reconcile pass — was present in code but not named in spec. |
-| ENEMY_CONTACT_RANGE_TILES | 0.8125 tile (= 26 px) | Derived from player + enemy visual radii in `## Visual` (14 px + 12 px) divided by `TILE_SIZE`. Specs/20 says "contact damage when within melee range" without naming a value; this range fires the hit exactly when the two discs visually touch. Captured during a reconcile pass (was inlined as a derived constant in `enemy_logic.rs`). |
-| Pain chance | 78% (200/255) | Chance to enter pain/stagger state when hit |
-| Pain duration | 0.17 seconds | Duration of pain stagger animation |
-| AI states | Idle, Chase, Pain, Death | Target adds: Attack |
+| ENEMY_CONTACT_RANGE_TILES | 0.8125 tile (= 26 px) | Derived from player + enemy visual radii in `## Visual` (14 px + 12 px) divided by `TILE_SIZE`. Retained as a public constant because the bot's kite-mode buffer (`BOT_KITE_RANGE` in § Autopilot) and the `RangedStandoff` demo-level rationale (specs/15) both reference it. The Attack state replaces contact damage as the trooper's primary harm vector — see `### Deferred from knowledge` below for the contact-melee rationale. |
+| Pain chance | 78% (200/255) | knowledge/enemy_types.md § Pain System ("Basic hitscan trooper (low HP) pain chance: 200/256 (~78%)"). Chance to enter pain/stagger state when hit. |
+| Pain duration | 0.17 seconds | knowledge/enemy_types.md § State Machine ("Pain: Two frames of 3 ticks each (6 ticks total, ~0.17 seconds)") at 35 ticks/sec. Pain interrupts whatever state the trooper was in (Idle, Chase, or Attack) and returns to Chase on expiry. |
+| AI states | Idle, Chase, Attack, Pain, Death | knowledge/enemy_types.md § State Machine. The Attack state was added in the 2026-05-13 combat slice (replacing the prior contact-damage path); per `### Deferred from knowledge` below, melee Idle/Chase/Pain/Death timings, the no-double-attack flag, and the distance-based attack probability check are deferred. |
+| Drop on death | Ammo clip (10 rounds) | knowledge/enemy_types.md § Death and Item Drops ("The basic hitscan trooper drops a clip (bullet ammo) on death"); knowledge/pickups.md § Drop on Kill ("basic hitscan trooper → small primary-ammo pickup (dropped, ~half clip-load)"). Knowledge says reference drops a *half*-clip via the "dropped" flag (5 rounds at our `PICKUP_AMMO_AMOUNT = 10`); the prototype simplifies by spawning the existing full-amount `Pickup { kind: Ammo, amount: PICKUP_AMMO_AMOUNT, active: true }` at the trooper's death position, reusing the `level.pickups` channel that the per-frame pickup check already drains. The half-clip "dropped" flag is deferred (single-amount ammo pickup; promotes to a richer pickup model when more enemy types ship). See specs/60 § Enemy Ammo Drops. |
 
-### Target (from knowledge, not yet implemented)
+### Deferred from knowledge
 
-| Constant | Value | Source |
-|----------|-------|--------|
-| Attack type | Hitscan at range | knowledge/enemy_types.md |
-| Attack range | 2048 map units | Same as player weapon range |
-| Attack spread | +/- 22 degrees max | Triangular distribution |
-| Attack sequence | 0.74 seconds | Wind-up, fire, cooldown |
-| Detection | Line of sight | No distance limit |
-| Idle scan period | 0.57 seconds per cycle | Two frames at 0.29s each |
-| Chase cycle time | 0.91 seconds | Eight frames at ~0.11s each |
-| Movement | 8-directional grid | Prefers diagonal toward player |
-| Target threshold | 2.86 seconds | Stubborn pursuit duration |
-| Move count | 0--15 steps | Steps before re-evaluating direction |
-| Active sound chance | 1.2% per chase frame | Ambient sound |
-| Radius | 20 map units | Collision size |
-| Height | 56 map units | Vertical extent |
-| Mass | 100 | Knockback resistance factor |
-| Gib threshold | -20 HP | Extreme death on overkill |
-| Drop on death | Ammo clip | Item dropped when killed |
+The prior `### Target` table is retired — every row that the prototype implements has moved into `### Implemented` above. The rows below are knowledge-documented behaviors that the prototype intentionally does NOT implement in this slice. Reconciler should not flag them as drift; they are tracked here so a future Architect pass can promote them when the spec scope expands.
+
+| Behavior | Knowledge source | Why deferred |
+|----------|-------------------|--------------|
+| Distance-based ranged-fire probability check | knowledge/enemy_types.md § Ranged Attack Probability Check | Knowledge describes a `random(0..255) < distance_with_modifiers` gate that suppresses some firings at long range. The prototype always fires when LoS, range, and Attack-state cooldown all hold — this overestimates the trooper's volume of fire at long range but keeps the per-frame logic simple. Promoted to a tunable when the enemy roster expands. |
+| No-double-attack flag | knowledge/enemy_types.md § Chase Behavior ("After attacking, sets a flag preventing it from attacking on the very next chase frame ... picks a new direction") | Knowledge says the trooper takes at least one chase frame between attacks AND switches direction. The prototype's Attack→Chase transition itself enforces "at least one tick of Chase between attacks" because the cooldown gate (`time_since_attack >= ENEMY_ATTACK_SEQUENCE_SEC`) is checked from Chase, but the direction-switch is not implemented. Visual symptom: the trooper may continue moving along the same axis between attacks. Cosmetic only. |
+| 8-directional grid movement (knowledge "prefers diagonal toward player") | knowledge/enemy_types.md § Chase Behavior, § Movement System | The prototype uses smooth axis-aligned slide (the same code path as `player_state::apply_input`) instead of an 8-direction grid. The on-screen result is similar (the trooper closes on the player along a roughly-direct path) but lacks the reference's "staircase" pathing aesthetic. Promoted when path visuals matter for the GIF. |
+| Idle scan period (0.57s cycle) | knowledge/enemy_types.md § State Machine ("Idle (Spawn): Two frames alternating with 10-tick durations") | Idle in the prototype is a single timer-based gate (`time_in_state >= ENEMY_REACTION_DELAY` then transitions to Chase). The two-frame scan animation is cosmetic; the LoS check itself is implicit because the prototype detects the player on the first Idle tick (no sweep arc). Promoted when sprite animation lands. |
+| Chase cycle time (0.91s, eight frames) | knowledge/enemy_types.md § State Machine, § Chase Behavior | The prototype's Chase tick runs once per frame at variable dt; the eight-frame animation cycle is cosmetic. |
+| Target threshold (2.86s stubborn pursuit) | knowledge/enemy_types.md § Chase Behavior | Single-target prototype — the trooper only "knows about" the player, so target switching is not implemented. Promoted when multi-enemy-vs-multi-target combat lands. |
+| Move count (0–15 steps before re-eval) | knowledge/enemy_types.md § Chase Behavior | Tied to the deferred 8-directional grid above. |
+| Active sound chance (1.2% per chase frame) | knowledge/enemy_types.md § Chase Behavior | Audio system not implemented. |
+| 180° forward visual arc during Idle scanning | knowledge/enemy_types.md § Detection and Alerting | The prototype's LoS check is omnidirectional (any LoS triggers detection). Visible symptom: a trooper detects a player approaching from behind, where the reference would not. Promoted when a behind-the-back grace period matters. |
+| Sound-based detection / sound propagation | knowledge/enemy_types.md § Detection and Alerting | Audio system not implemented. |
+| Reject-table optimization for LoS | knowledge/enemy_types.md § Line of Sight | Map-asset optimization; the prototype's tile-grid ray-cast is fast enough at 20×15. |
+| Eye height (3/4 of total height) | knowledge/enemy_types.md § Line of Sight | The prototype is 2D — eye height is meaningless without vertical map geometry. Tracked by specs/45 for the raycaster renderer (already deferred there). |
+| Radius / Height / Mass (collision/knockback) | knowledge/enemy_types.md § Enemy Constants Summary | Mass-based knockback and 56-unit vertical extent are map-format properties; the prototype uses `ENEMY_RADIUS_TILES` (rescaled from visual radius) for collision and has no knockback. |
+| Gib threshold (-20 HP) | knowledge/enemy_types.md § Death and Item Drops | Single death animation; gib animation deferred (specs/40 § Deferred). |
+| Half-amount "dropped" ammo clip | knowledge/pickups.md § Drop on Kill, § Ammo Pickup Tiers | Single-amount ammo pickup in the prototype; the half-clip rule promotes when a richer pickup model lands (separate small/large/dropped variants). |
 
 ## Weapon (Pistol -- starting weapon)
 

--- a/specs/60_pickups.md
+++ b/specs/60_pickups.md
@@ -45,6 +45,22 @@ Source: [`knowledge/pickups.md`](../knowledge/pickups.md). Spec values that are 
 - Same "leave in list, just deactivate" rule.
 - Auto-weapon-switch on zero→nonzero ammo (knowledge § Ammo Pickup Tiers, "auto-switch to best owned weapon") is **deferred** — the prototype has only one weapon, no switch is meaningful.
 
+### Enemy Ammo Drops
+
+**Trigger:** During the per-frame `game_loop::update` sequence, an enemy's `alive` flag transitions from `true` to `false` (via `enemy_logic::take_damage` from a player hitscan that drops the trooper to ≤ 0 HP).
+
+**Effect:** Exactly one `Pickup { kind: PickupKind::Ammo, pos: enemy.pos, active: true }` is appended to `Level::pickups` at the trooper's death position. The pickup is collectible by the existing per-frame pickup check on the next frame.
+
+**Rules:**
+- The drop is gated by an `Enemy.ammo_drop_spawned: bool` latch: initialized `false`, flipped to `true` after the push so the scan never double-spawns. *(Knowledge: § Drop on Kill — "deterministic per enemy kind, no random roll".)*
+- The push happens in the dedicated drop-spawn step of `game_loop::update`'s frame-update order (`ir/contracts/_shared.yaml § frame_update_order`), AFTER the enemy update loop AND AFTER `weapon_system::fire`. This ensures a same-frame kill (player hitscan kills the trooper this tick) drops the pickup this tick rather than next tick. The drop is NOT pushed inside `enemy_logic::take_damage` because that call site only holds `&Level`, not `&mut Level::pickups` — pushing into the level requires the orchestration borrow that only `game_loop::update` owns. *(Service-emit decision recorded in `ir/contracts/_shared.yaml § service_emit_decisions § game_loop drop-spawn scan`.)*
+- The pickup uses the existing `PickupKind::Ammo` and `PICKUP_AMMO_AMOUNT = 10` rounds — the half-clip "dropped" flag from knowledge (5 rounds for the basic trooper) is **deferred** to the richer-pickup-model slice. The prototype's single-amount ammo pickup means the drop grants the same rounds as a placed ammo box, which makes enemy-farming slightly more rewarding than the reference; tracked in `25_game_tuning.md § Enemy § Deferred from knowledge`.
+- Because the drop appears in `Level::pickups` only AFTER the per-frame pickup check has already run this frame, the player cannot collect the drop on the same frame it is created — earliest collection is the NEXT frame. This is a one-frame delay (16 ms at 60 FPS), imperceptible.
+- The drop respects the existing "refused at cap" rule: if the player is at `PLAYER_AMMO_MAX` when they walk over the dropped pickup, the pickup stays active and is collected later when there is room.
+- The drop position is the trooper's `pos` at the moment of death — not the enemy's spawn position, not snapped to a tile. The renderer draws the dropped pickup at this floating-point position via the same code path that draws placed pickups.
+
+*(Knowledge: § Drop on Kill — "spawns one pickup at the enemy's feet"; § Cap Behavior — "refused, pickup remains in world".)*
+
 ### Per-Frame Pickup Check
 
 **Trigger:** Once per frame, in `game_loop::update`, after player movement (`apply_input`) and before enemy updates.
@@ -129,7 +145,8 @@ Source: [`knowledge/pickups.md`](../knowledge/pickups.md). Spec values that are 
 
 ### With Game Loop
 - `game_loop::update` adds Step 2.5 between `apply_input` (Step 2) and the enemy update (Step 3): scan `state.level.pickups` for the first active pickup within `PICKUP_RADIUS_TILES` of `state.player.pos` whose acceptance condition holds, and consume it.
-- The frame-update-order list in `ir/contracts/_shared.yaml § frame_update_order` gains the new step.
+- `game_loop::update` adds the drop-spawn step AFTER the enemy update loop AND AFTER `weapon_system::fire`: scan `state.enemies` for trooper deaths and push `Pickup { kind: PickupKind::Ammo, pos: enemy.pos, active: true }` into `state.level.pickups` (gated by `Enemy.ammo_drop_spawned`). See § Enemy Ammo Drops above.
+- The frame-update-order list in `ir/contracts/_shared.yaml § frame_update_order` gains both steps.
 
 ### With Renderer
 - `renderer::draw` adds Step 2.5 (between exit/corpses and blood/puffs) drawing active pickups.
@@ -164,7 +181,7 @@ The following are intentionally out of scope for the prototype:
 - **Pickup respawn** — single-use within a run.
 - **Pickup pickup sound / dry-fire "click"** — no audio system in the prototype.
 - **Backpack / capacity expansion** — fixed `PLAYER_AMMO_MAX`.
-- **Enemy ammo drops** — knowledge § Drop on Kill documents this; deferred until enemy_logic gets a death-time spawn hook.
+- **Half-clip "dropped" flag** — knowledge § Drop on Kill + § Ammo Pickup Tiers say a basic-trooper drop yields 5 rounds (half a clip) vs the placed-pickup 10 rounds. The prototype's single-amount `PICKUP_AMMO_AMOUNT = 10` ignores the dropped/placed distinction. The trooper death-time drop itself is **implemented** in the 2026-05-13 combat slice (see § Enemy Ammo Drops above) — only the half-amount flag is deferred.
 - **Skill multiplier (2× ammo on easiest/hardest)** — knowledge § Difficulty / Skill Multipliers. No skill system in the prototype.
 - **Pickup categories beyond health/ammo** — armor, keycards, all powerups. Knowledge mentions them; deferred.
 - **HUD low-ammo warning color** — ammo digits are single-color (yellow).
@@ -205,11 +222,12 @@ The following are intentionally out of scope for the prototype:
 
 **Implemented:**
 - `Pickup` and `PickupKind` types homed in `level_data`.
-- `Level::pickups` field populated by `build_default` with one health and one ammo pickup at fixed positions (spec/25 § Pickups § Default Level Placement).
+- `Level::pickups` field populated by `build_default` with one health and one ammo pickup at fixed positions (spec/25 § Pickups § Default Level Placement). Demo levels (`level_generator`) seed their own `Vec<Pickup>` per the layout pinned in `specs/15_level_generator.md`.
 - `Player.ammo` field, initialized to `PLAYER_AMMO_INITIAL` by `player_state::new`.
 - `player_state::take_health_pickup` and `player_state::take_ammo_pickup` (clamped to caps).
 - `weapon_system::fire` ammo gate (top of function, after cooldown gate) and per-shot decrement.
 - `game_loop::update` Step 2.5 per-frame pickup check (refused-at-cap rule applied).
+- `game_loop::update` drop-spawn scan after the enemy update + weapon-fire steps (specs/60 § Enemy Ammo Drops): pushes one `Pickup { kind: Ammo, pos: enemy.pos, active: true }` per dead trooper, gated by `Enemy.ammo_drop_spawned`.
 - Renderer pickup layer (between exit/corpses and blood/puffs).
 - HUD ammo pane (icon + digits, below the health pane).
 - Pickup tint flash: `visual_effects::increment_pickup_tint` called on consumption; golden-yellow overlay spec in `specs/40 § Pickup Tint Screen Flash`.
@@ -222,7 +240,7 @@ The following are intentionally out of scope for the prototype:
 - Pickup respawn.
 - Pickup audio.
 - Backpack / capacity expansion.
-- Enemy ammo drops.
+- Half-clip "dropped" flag (knowledge says basic-trooper drops yield 5 rounds vs the placed-pickup 10 rounds; the prototype's single-amount `PICKUP_AMMO_AMOUNT = 10` ignores the dropped/placed distinction). Promotes when a richer pickup model lands.
 - Skill multiplier.
 - Pickup categories beyond health/ammo.
 - HUD low-ammo warning color.


### PR DESCRIPTION
Closes #67

Generated by `agent-intake.yml` run [#25781416176](https://github.com/RuslanMingaliev/worldsmith/actions/runs/25781416176).

Issue scope, usage stats, and the unified diff are attached as workflow artifacts.