### PR TITLE
release.yml: stage prior-release src for Reconciler diff (ADR-2)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,11 +81,63 @@ jobs:
           sudo npm install -g @anthropic-ai/claude-code
           claude --version
 
+      - name: Stage prior-release source for Reconciler diff
+        id: prev_src
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -e
+          # Reconciler's release-mode addendum diffs per-module test counts
+          # against the prior release in addition to `generated-snapshot`.
+          # Release tags do not contain `generated/` (gitignored), so the
+          # source for the prior release lives only inside its
+          # `worldsmith-game-<prev>-src.zip` asset. Download + unpack it to a
+          # known path and thread that path into Reconciler's Scope block.
+          PREV=$(gh release list --exclude-drafts --limit 5 \
+                  --json tagName --jq ".[] | select(.tagName != \"$VERSION\") | .tagName" \
+                  | head -n1)
+          if [ -z "$PREV" ]; then
+            PREV=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
+          fi
+          if [ -z "$PREV" ]; then
+            echo "::warning::No prior release tag found; Reconciler prev-release diff will be skipped."
+            echo "tag=" >> "$GITHUB_OUTPUT"
+            echo "src_dir=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Prior release tag: $PREV"
+          mkdir -p artifacts/prev-release-src
+          STAGE=$(mktemp -d)
+          ASSET="worldsmith-game-${PREV}-src.zip"
+          if ! gh release download "$PREV" --pattern "$ASSET" --dir "$STAGE"; then
+            echo "::warning::Could not download $ASSET from release $PREV; Reconciler prev-release diff will be skipped."
+            echo "tag=$PREV" >> "$GITHUB_OUTPUT"
+            echo "src_dir=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          unzip -q "$STAGE/$ASSET" -d "$STAGE/unpack"
+          # Layout (per package_release.py): worldsmith-game-<PREV>/src/<module>.rs
+          INNER_SRC="$STAGE/unpack/worldsmith-game-${PREV}/src"
+          if [ ! -d "$INNER_SRC" ]; then
+            echo "::warning::Expected $INNER_SRC inside $ASSET but not found; layout may have changed."
+            ls -la "$STAGE/unpack" || true
+            echo "tag=$PREV" >> "$GITHUB_OUTPUT"
+            echo "src_dir=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          cp -a "$INNER_SRC/." artifacts/prev-release-src/
+          echo "Unpacked $(ls artifacts/prev-release-src/ | wc -l) module files to artifacts/prev-release-src/"
+          echo "tag=$PREV" >> "$GITHUB_OUTPUT"
+          echo "src_dir=artifacts/prev-release-src" >> "$GITHUB_OUTPUT"
+
       - name: Run pipeline
         env:
           # Bills the operator's claude.ai Pro/Max subscription. Generated locally via
           # `claude setup-token` and stored as a repository secret.
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          PREV_RELEASE_SRC: ${{ steps.prev_src.outputs.src_dir }}
+          PREV_RELEASE_TAG: ${{ steps.prev_src.outputs.tag }}
         run: |
           set -e
           if [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]; then
@@ -95,7 +147,13 @@ jobs:
           mkdir -p artifacts
           python tooling/orchestrator_run.py --mode release --phase architect
           python tooling/orchestrator_run.py --mode release --phase coder
-          python tooling/orchestrator_run.py --mode release --phase reconciler
+          if [ -n "${PREV_RELEASE_SRC:-}" ]; then
+            RECONCILER_SCOPE="prev_release_src: ${PREV_RELEASE_SRC}; prev_release_tag: ${PREV_RELEASE_TAG}"
+            python tooling/orchestrator_run.py --mode release --phase reconciler \
+              --scope "$RECONCILER_SCOPE"
+          else
+            python tooling/orchestrator_run.py --mode release --phase reconciler
+          fi
           python tooling/orchestrator_run.py --mode release --phase postmortem
 
       - name: Post-flight validate (catch accidental knowledge writes)

--- a/tooling/agents/reconciler.md
+++ b/tooling/agents/reconciler.md
@@ -66,16 +66,19 @@ Any module where `POST < PRE` is a **coverage regression** — log under `### Dr
 
 Bare `Tests passing: N / N` in the report is **insufficient** when N decreased between regens. The 2026-05-08 release regen on commit `9ec001f` shipped 35 tests vs. 64 in the prior commit `b3a5237` — net loss of ~27 unit tests across `autopilot.rs` (-9), `game_loop.rs` (-5), `renderer.rs` (-4), and others. Reconciler's report read "Tests passing: 35 / 35" without flagging the drop; PostMortem propagated the same framing. The coverage hole would have baselined into `generated-snapshot` on merge, making restoration progressively harder for future PRs.
 
-**Release-mode addendum.** In release mode (orchestrator invoked with `--mode release` and no `--target-modules`), run the same grep against the **prior release tag** in addition to `generated-snapshot`:
+**Release-mode addendum.** In release mode, when `release.yml` has staged the prior release's source tree, the orchestrator threads its location into the `## Scope override` block as `prev_release_src: <path>; prev_release_tag: <tag>`. When that key is present, run the same grep against the prior release in addition to `generated-snapshot`:
 
 ```
-# previous_tag is provided by the orchestrator's `## Scope override` block.
-PRE_REL=$(git show <previous_tag>:generated/game/src/<module>.rs 2>/dev/null \
-          | grep -c '#\[test\]' || echo 0)
+# prev_release_src is provided by the orchestrator's `## Scope override` block;
+# it points at a flat directory of <module>.rs files extracted from the prior
+# release's worldsmith-game-<prev>-src.zip asset.
+PRE_REL=$(grep -c '#\[test\]' <prev_release_src>/<module>.rs 2>/dev/null || echo 0)
 PRE_SNAP=$(git show origin/generated-snapshot:src/<module>.rs 2>/dev/null \
            | grep -c '#\[test\]' || echo 0)
 POST=$(grep -c '#\[test\]' generated/game/src/<module>.rs)
 ```
+
+If the Scope block has no `prev_release_src` key (PR-mode invocation, first release with no prior tag, or asset download failed), skip the prior-release grep with a one-line note under `### Drift found` ("prior-release diff unavailable: prev_release_src not provided in scope") and rely on `PRE_SNAP` as the regression floor. Do NOT attempt `git show <previous_tag>:generated/...` as a fallback — `generated/` is gitignored, so release tags do not contain the generated tree, and the `git show` returns empty silently. The earlier version of this addendum (PR #61) used that recipe and burned ~5–8 turns per release on the dead path; the staging step in `release.yml` (added 2026-05-14) is the single supported source.
 
 Both diffs matter and the severity is the same release-blocker tier: `POST < PRE_REL` is the user-facing claim ("did this release regress coverage vs the last published release?") and goes verbatim into the Reconciler report so release_editor can reflect it in release notes; `POST < PRE_SNAP` catches drift accumulated between releases that should not propagate to the next snapshot. Log both as separate entries under `### Drift found` so PostMortem can distinguish "release-window drift" from "this-regen drift". The 2026-05-11 release regen shipped 61 tests vs. 77 in `generated-snapshot` (release-blocker D3) but the prior-release diff was never computed, so the user-facing line in release notes silently claimed "gameplay unchanged" — see release_editor.md § Inputs you should read.
 


### PR DESCRIPTION
Reconciler's release-mode addendum (PR #61) diffs per-module test counts against the prior release tag in addition to `generated-snapshot`, so release notes can make a confident "gameplay unchanged" / "tests regressed by N" claim. The recipe was non-functional: `git show <prev_tag>:generated/game/src/<module>.rs` returned empty because `generated/` is gitignored and release tags do not contain the generated tree. Every Reconciler since the recipe landed (2026-05-11, 2026-05-13, 2026-05-14) burned ~5–8 turns chasing the dead path before skipping with a manual note. The 2026-05-11 release shipped 61 tests vs. 77 in `generated-snapshot` (D3 release-blocker) but the user-facing release-notes line silently claimed "gameplay unchanged" because the prior-release diff never ran.

Two layers were missing per ADR-2 in PR #78's PostMortem:

1. **Source-of-truth availability.** The prior release's source tree only exists inside `worldsmith-game-<prev>-src.zip` on the GitHub Release. Nothing in the workflow downloaded or unpacked it.
2. **Reconciler scope threading.** Reconciler is invoked with no `--scope`, so it has no structured signal for "use this path as the prior-release baseline".

This PR adds both layers.

`release.yml` `generate` job gets a new "Stage prior-release source" step before the pipeline run: determines the prior release tag (same logic the `release` job already uses), downloads `worldsmith-game-<prev>-src.zip`, unpacks `worldsmith-game-<prev>/src/` to a flat directory at `artifacts/prev-release-src/`. The Reconciler invocation now passes `--scope "prev_release_src: artifacts/prev-release-src; prev_release_tag: <tag>"` when the staging step succeeded. Any failure (no prior tag, asset 404, layout drift) warns and runs Reconciler without the scope key — the addendum's skip branch fires cleanly.

`tooling/agents/reconciler.md` swaps the dead `git show` recipe for one that reads from the threaded path, and explicitly forbids the old fallback so it doesn't get reintroduced. The skip-on-missing branch becomes the canonical PR-mode behavior (pr.yml does not stage the source, so PR-mode Reconciler skips the prior-release diff with a one-line note and relies on `PRE_SNAP` as the floor — which is correct: PR snapshot diff is the per-PR floor; release-tag diff is the release-notes-integrity floor).

`pr.yml` is intentionally untouched. Mode-detection ambiguity (PostMortem also flagged this) is now resolved structurally: presence of `prev_release_src` in scope is the positive signal that this is a release-mode invocation with prior-release baseline available, instead of relying on the broken `Mode: release` framing string.

The next release run will exercise the path. If the staging step warns, the Reconciler still runs (with scope omitted) and the addendum skips cleanly — no regression vs. current behavior.