### PR TITLE
tooling: bump default max-turns from 160 to 240

### DIFF
--- a/tooling/orchestrator_run.py
+++ b/tooling/orchestrator_run.py
@@ -24,7 +24,7 @@ Inputs:
 - --scope            optional free-text scope (forwarded into the prompt)
 - --usage-jsonl      output path for the usage record (default: artifacts/usage.jsonl)
 - --transcript       optional path to also save the raw stream-json transcript
-- --max-turns        cap on agent turns (default: 160)
+- --max-turns        cap on agent turns (default: 240)
 - --model            override the Claude model id (default: inherits from CLI/env)
 
 Exit codes:
@@ -363,7 +363,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--scope", default=None)
     parser.add_argument("--usage-jsonl", type=Path, default=DEFAULT_USAGE)
     parser.add_argument("--transcript", type=Path, default=None)
-    parser.add_argument("--max-turns", type=int, default=160)
+    parser.add_argument("--max-turns", type=int, default=240)
     parser.add_argument("--model", default=None)
     parser.add_argument(
         "--target-modules",


### PR DESCRIPTION
Architect on the combat slice 4 intake (issue #70: ammo categories split + shell pickup) hit the 160-turn cap after 26 minutes / \$30.29 / 108k output tokens (workflow run [25984761981](https://github.com/RuslanMingaliev/worldsmith/actions/runs/25984761981), `terminal_reason=max_turns`, `num_turns=161`). The phase was clearly mid-task — slice 4's scope is structurally heavier than slice 3 (4 knowledge sections, 4 spec sections, 3 IR contracts, enum split across `player_state`) and needs more turns.

Conservative 50% headroom: at the observed ~\$0.19/turn the cost ceiling for an exhausting Architect rises from ~\$30 to ~\$45. Bounded; `WORLDSMITH_MAX_TOKENS_PER_RUN` is still the global escape hatch if needed.

Mirrors the prior 80 → 160 bump (PR #27, commit 9e5150b). Affects all callers that don't pass `--max-turns` explicitly: `agent-intake.yml`, `release.yml`, `pr.yml`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>